### PR TITLE
[EWLJ-217] JoE | Remove extra space around "Accessed on"

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_references.scss
+++ b/styleguide/source/assets/scss/02-molecules/_references.scss
@@ -19,8 +19,7 @@
   margin-bottom: 1em;
 }
 
-.joe__references__item-links,
-.joe__references li {
+.joe__references__item-links{
   a {
     margin-right: 15px;
   }


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWLJ-217: JoE | Remove extra space around "Accessed on"](https://issues.ama-assn.org/browse/EWLJ-217)

## Description
When a user adds a "Last accessed" link to a reference on an article, it renders on in the references with a space after the link. This is due to the 15px margin-right that was added to the Google and PubMed (and other) links. That space should remain after the journal links, but should not appear after a "Last accessed" link .

This update removes the css causing all links within references to have margins.


## To Test
- Pull `bugfix/EWLJ-217-remove-extra-space-around-link` branch
- Run `gulp serve` in joe-style-guide-2/styleguide to ensure a local version of style guide is running.
- Pull `develop` branch of ama-d8.
- Update local provision config file to point to local instance of `joe-style-guide`.
- Run `vagrant up`, `vagrant ssh`, and `scripts/refresh-local -a joe` to get an updated version of the JoE db.
- Visit an article page that has reference links such as [Clinicians’ Need for an Ecological Approach to Violence Reduction](http://ama-joe.local/article/clinicians-need-ecological-approach-violence-reduction/2018-01) and confirm links within citations do not have right margin.

## Visual Regressions
The repo does not use a visual regression testing system.


## Relevant Screenshots/GIFs
### Article in D8
![image](https://user-images.githubusercontent.com/4438120/41242720-e731cc26-6d65-11e8-8477-c5ebe8756286.png)


## Remaining Tasks
N/A


## Additional Notes
N/A
