### PR TITLE
[EWLJ-230] Table headers left justified

### DIFF
--- a/styleguide/source/assets/scss/01-atoms/_table.scss
+++ b/styleguide/source/assets/scss/01-atoms/_table.scss
@@ -18,6 +18,11 @@ table {
   @include breakpoint($bp-large) {
     white-space: normal;
   }
+  
+  caption{
+    text-align: left;
+    padding: 0px 12px;
+  }
 
   // change these gradients from white to your background colour if it differs
   // gradient on the first cells to hide the left shadow


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWLJ-230: Table headers left justified](https://issues.ama-assn.org/browse/EWLJ-230)

## Description
The table caption needs to be left justified according the AMA style for Journal of Ethics. This update adds styles to ensure table caption is left aligned.


## To Test
- Pull `bugfix/EWLJ-230-table-headers-left-justified` branch
- Run `gulp serve` in joe-style-guide-2/styleguide to ensure a local version of style guide is running.
- Pull `develop` branch of ama-d8.
- Update local provision config file to point to local instance of `joe-style-guide`.
- Run `vagrant up`, `vagrant ssh`, and `scripts/refresh-local -a joe` to get an updated version of the JoE db.
- Visit an [article page that has a table within the body](http://ama-joe.local/article/why-arent-our-digital-solutions-working-everyone/2017-11) or add a table with caption to any existing article and confirm that the caption is left aligned.

## Visual Regressions
The repo does not use a visual regression testing system.


## Relevant Screenshots/GIFs
#### Article with table and caption
![image](https://user-images.githubusercontent.com/4438120/41545458-d192efe6-72e0-11e8-8e24-eff9f8b87d27.png)



## Remaining Tasks
N/A


## Additional Notes
N/A
