### PR TITLE
[EWLJ-220] JoE | block quotes should not be pull quotes

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_inline-quote.scss
+++ b/styleguide/source/assets/scss/02-molecules/_inline-quote.scss
@@ -1,7 +1,6 @@
 blockquote {
-  font-size: .85em;
   margin: 1em auto;
-  line-height: 1.4;
+  @include type($base-font-family, .85em, $font-weight-medium, 1.4);
 }
 
 .joe__inline-quote{

--- a/styleguide/source/assets/scss/02-molecules/_inline-quote.scss
+++ b/styleguide/source/assets/scss/02-molecules/_inline-quote.scss
@@ -1,5 +1,10 @@
-.joe__inline-quote,
 blockquote {
+  font-size: .85em;
+  margin: 1em auto;
+  line-height: 1.4;
+}
+
+.joe__inline-quote{
   @extend %joe__inline;
   @include type($font-serif, 1.1em, $font-weight-bold, 1.35);
   color: $navy-lighter;


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWLJ-220: JoE | block quotes should not be pull quotes](https://issues.ama-assn.org/browse/EWLJ-220)

## Description
Pull quotes and block quotes are different, and should appear differently. This update changes styles to ensure a generic blockquote element is not automatically rendered as a pull quote.

Please note that an editor may have added italicized text within a block quote. The style updates do not force additional styling on other elements within the blockquote.


## To Test
- Pull `bugfix/EWLJ-220-block-quotes-pull-quotes` branch
- Run `gulp serve` in joe-style-guide-2/styleguide to ensure a local version of style guide is running.
- Pull `develop` branch of ama-d8.
- Update local provision config file to point to local instance of `joe-style-guide`.
- Run `vagrant up`, `vagrant ssh`, and `scripts/refresh-local -a joe` to get an updated version of the JoE db.
- Visit an [article page with a block quote](http://ama-joe.local/article/why-arent-our-digital-solutions-working-everyone/2017-11) or add a block quote to any existing article and confirm that the styling is same as paragraphs with smaller text.


## Visual Regressions
The repo does not use a visual regression testing system.


## Relevant Screenshots/GIFs
N/A


## Remaining Tasks
N/A


## Additional Notes
N/A
