### PR TITLE
EWLJ-264 moves filter block to top of page for tablet and mobile

### DIFF
--- a/styleguide/source/assets/scss/04-templates/_two_column-left.scss
+++ b/styleguide/source/assets/scss/04-templates/_two_column-left.scss
@@ -113,14 +113,20 @@
 
 .joe__sidebar {
   grid-column: 1;
-  grid-row: 5;
-  -ms-grid-row: 5;
+  grid-row: 2;
+  -ms-grid-row: 2;
+
   min-width: 0;
   margin-left: $gutter-mobile;
   margin-right: $gutter-mobile;
   padding-top: 1px;
   padding-bottom: 1px;
-  
+
+  @include breakpoint($bp-large) {
+    grid-row: 5;
+    -ms-grid-row: 5;
+  }
+
   .is-listing & {
     grid-row: 2;
     -ms-grid-row: 2;

--- a/styleguide/source/assets/scss/04-templates/_two_column-left.scss
+++ b/styleguide/source/assets/scss/04-templates/_two_column-left.scss
@@ -113,19 +113,14 @@
 
 .joe__sidebar {
   grid-column: 1;
-  grid-row: 2;
-  -ms-grid-row: 2;
+  grid-row: 5;
+  -ms-grid-row: 5;
 
   min-width: 0;
   margin-left: $gutter-mobile;
   margin-right: $gutter-mobile;
   padding-top: 1px;
   padding-bottom: 1px;
-
-  @include breakpoint($bp-large) {
-    grid-row: 5;
-    -ms-grid-row: 5;
-  }
 
   .is-listing & {
     grid-row: 2;
@@ -144,6 +139,16 @@
     .is-listing & {
       grid-row: 2;
       -ms-grid-row: 2;
+    }
+  }
+
+  &__ethics-cases {
+    grid-row: 2;
+    -ms-grid-row: 2;
+
+    @include breakpoint($bp-large) {
+      grid-row: 5;
+      -ms-grid-row: 5;
     }
   }
   


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**

- [EWLJ-264: Filter function for cases](https://issues.ama-assn.org/browse/EWLJ-264)


## Description

Filter block is at the bottom of page on mobile and tablet when it should be on top


## To Test

- [ ] switch both Styleguide and D8 JOE branches to `feature/EWLJ-264-filter-location`
- [ ] cd into `styleguide` directory 
-[ ]  `gulp serve`
- [ ] enable local JOE styleguide in your D8 local.yml
- [ ] `scripts/build`
- [ ] visit http://ama-joe.local/cases
- [ ] switch your viewport to mobile and tablet
- [ ] observe the filter block is now on top of the articles

## Visual Regressions

n/a

## Relevant Screenshots/GIFs

![screen shot 2018-12-17 at 11 43 50 am](https://user-images.githubusercontent.com/2271747/50104981-0c806d00-01f1-11e9-84a8-42bbd07c401a.png)
![screen shot 2018-12-17 at 11 43 33 am](https://user-images.githubusercontent.com/2271747/50104982-0c806d00-01f1-11e9-8236-88aff4a2d2f5.png)

## Remaining Tasks

Remaining tasks?
n/a

## Additional Notes

Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?
