### PR TITLE
EWLJ-329: Secondary navigation should sit flush right

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_utility-nav.scss
+++ b/styleguide/source/assets/scss/02-molecules/_utility-nav.scss
@@ -13,7 +13,7 @@
   @include breakpoint($bp-med) {
     position: absolute;
     width: 93%;
-    max-width: 1550px;
+    max-width: 1600px;
     margin: 0 auto;
     column-count: 1;
     background: $navy-lighter;
@@ -27,7 +27,7 @@
   }
   
   @include breakpoint($bp-large) {
-    width: 94%;
+    width: 95%;
     
     .joe__header & {
       top: -28px;

--- a/styleguide/source/assets/scss/02-molecules/_utility-nav.scss
+++ b/styleguide/source/assets/scss/02-molecules/_utility-nav.scss
@@ -12,7 +12,7 @@
   
   @include breakpoint($bp-med) {
     position: absolute;
-    width: 93%;
+    width: 100%;
     max-width: 1600px;
     margin: 0 auto;
     column-count: 1;
@@ -27,7 +27,7 @@
   }
   
   @include breakpoint($bp-large) {
-    width: 95%;
+    width: 100%;
     
     .joe__header & {
       top: -28px;
@@ -54,10 +54,15 @@
   
   @include breakpoint($bp-med) {
     float: right;
+    margin-right: 5em;
+  }
+
+  @include breakpoint($bp-large) {
+    margin-right: 5em;
   }
   
   @include breakpoint($bp-xl) {
-    margin-right: 1.75em;
+    margin-right: 0em;
   }
 }
 

--- a/styleguide/source/assets/scss/02-molecules/_utility-nav.scss
+++ b/styleguide/source/assets/scss/02-molecules/_utility-nav.scss
@@ -8,22 +8,23 @@
   
   @include breakpoint($bp-xs) {
     column-count: 2;
-  }
-  
-  @include breakpoint($bp-med) {
+
     position: absolute;
     width: 100%;
     max-width: 1600px;
     margin: 0 auto;
-    column-count: 1;
     background: $navy-lighter;
     background-color: $navy-lighter;
-    
+
     .joe__header & {
       top: -25px;
       background: none;
       background-color: transparent;
     }
+  }
+  
+  @include breakpoint($bp-med) {
+    column-count: 1;
   }
   
   @include breakpoint($bp-large) {

--- a/styleguide/source/assets/scss/02-molecules/_utility-nav.scss
+++ b/styleguide/source/assets/scss/02-molecules/_utility-nav.scss
@@ -54,11 +54,11 @@
   
   @include breakpoint($bp-med) {
     float: right;
-    margin-right: 5em;
+    margin-right: 5.0em;
   }
 
   @include breakpoint($bp-large) {
-    margin-right: 5em;
+    margin-right: 5.0em;
   }
   
   @include breakpoint($bp-xl) {


### PR DESCRIPTION
**Jira Ticket**

- [EWLJ-329: Secondary navigation should sit flush right](https://issues.ama-assn.org/browse/EWLJ-329)


## Description

Adjusts the max-width property for the secondary nav (links with menu text: Signup Newsletter Follow Us). Makes the utility navigation menu flush to the right of the page, aligns with the search bar. 

<img width="1355" alt="screen shot 2019-02-26 at 3 39 55 pm" src="https://user-images.githubusercontent.com/541745/53444706-dc1d3200-39dc-11e9-9c9f-dfcb441b2cc7.png">


## To Test

- [ ] run `gulp serve`
- [ ] enable local SG2 testing in your D8 env
- [ ] in your D8 instance run `drush @joe.local cr`
- [ ] check that the twitter icon and it's menu doesn't lag behind the search box at wide viewports. For example here: http://ama-joe.local/home

## Visual Regressions

N/A

## Relevant Screenshots/GIFs

N/A


## Remaining Tasks

Remaining tasks?
N/A

## Additional Notes
N/A
