### PR TITLE
[EWLJ-309] Sort drop down for search results page

### DIFF
--- a/styleguide/source/_patterns/02-molecules/search-page-filters.json
+++ b/styleguide/source/_patterns/02-molecules/search-page-filters.json
@@ -1,0 +1,26 @@
+{
+  "input": {
+    "type": "search",
+    "name": "site-search",
+    "id": "keyword-search",
+    "class": "joe__search-bar__input-search",
+    "value": "",
+    "placeholder": "Search our Journal"
+  },
+  "select": {
+    "name": "select",
+    "id": "sort-search",
+    "class": "joe__search-bar__select",
+    "options": [
+      {
+        "value":"relevance",
+        "name":"Relevance",
+        "selected" : true
+      },
+      {
+        "value":"most_recent",
+        "name":"Most recent"
+      }
+    ]
+  }
+}

--- a/styleguide/source/_patterns/02-molecules/search-page-filters.twig
+++ b/styleguide/source/_patterns/02-molecules/search-page-filters.twig
@@ -1,6 +1,8 @@
 <form class="joe__search-bar">
   <label class="visually-hidden">Site Search</label>
-  <input type="search" name="site-search" placeholder="Search our Journal" />
+  {% include "@atoms/input.twig" %}
+  <label class="visually-hidden">Sort Search</label>
+  {% include "@atoms/select.twig" %}
   <input type="submit" name="site-search-submit" value="Search"/>
 </form>
 

--- a/styleguide/source/_patterns/05-pages/search-results.json
+++ b/styleguide/source/_patterns/05-pages/search-results.json
@@ -61,6 +61,32 @@
       "value": "Search"
     }
   ],
+  "search_filter": {
+    "input": {
+      "type": "search",
+      "name": "site-search",
+      "id": "keyword-search",
+      "class": "joe__search-bar__input-search",
+      "value": "",
+      "placeholder": "Search our Journal"
+    },
+    "select": {
+      "name": "select",
+      "id": "sort-search",
+      "class": "joe__search-bar__select",
+      "options": [
+        {
+          "value":"relevance",
+          "name":"Relevance",
+          "selected" : true
+        },
+        {
+          "value":"most_recent",
+          "name":"Most recent"
+        }
+      ]
+    }
+  },
   "utility_left_navs": [
     {
       "href": "/",

--- a/styleguide/source/_patterns/05-pages/search-results.twig
+++ b/styleguide/source/_patterns/05-pages/search-results.twig
@@ -6,7 +6,7 @@
 
 {% block pageContent_header %}
     {% include '@molecules/page-header.twig' %}
-    {% include '@molecules/search-page-filters.twig' %}
+    {% include '@molecules/search-page-filters.twig' with { "input": search_filter.input, "select": search_filter.select } %}
 {% endblock %}
 
 {% block sidebar_top %}

--- a/styleguide/source/assets/scss/03-organisms/_search-page-filters.scss
+++ b/styleguide/source/assets/scss/03-organisms/_search-page-filters.scss
@@ -13,7 +13,8 @@
     position: relative;
     padding-right: 140px;
     flex-direction: row;
-    
+    justify-content: center;
+
     input[type='submit'] {
       width: auto;
       margin-top: 0;

--- a/styleguide/source/assets/scss/03-organisms/_search-page-filters.scss
+++ b/styleguide/source/assets/scss/03-organisms/_search-page-filters.scss
@@ -1,7 +1,10 @@
 .joe__search-bar {
   margin: 1em 0;
+  display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
   
-  input[type='submit'] {
+  input[type='submit'], &__select {
     width: 100%;
     margin-top: .25em;
   }
@@ -9,6 +12,7 @@
   @include breakpoint($bp-xs) {
     position: relative;
     padding-right: 140px;
+    flex-direction: row;
     
     input[type='submit'] {
       width: auto;
@@ -16,7 +20,17 @@
       position: absolute;
       right: 0;
       top: 0;
-    } 
+    }
+    &__input-search{
+      flex: 2 0 60%;
+      max-width: 100%;
+      margin-right: 1em;
+    }
+    &__select{
+      max-width: 25%;
+      flex: 0 1 25%;
+      margin-top: 0;
+    }
     
     @include breakpoint($bp-med) {
       padding-right: 160px;


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**
- [EWLJ-309 SG | Design a sort drop down to search results page](https://issues.ama-assn.org/browse/EWLJ-309)

## Description
Adds templates and styling for search sort dropdown on search result pages.


## To Test
- Pull `feature/EWLJ-309-search-results-sort` branch
- Run `gulp serve` in joe-style-guide-2/styleguide to ensure a local version of style guide is running.
- Visit the [search results page](http://localhost:3000/?p=pages-search-results) and confirm it looks as it does in the mockup attached to the above referenced ticket.
- Confirm mobile view looks as described in above referenced ticket.
- Check page in IE11 and Firefox and confirm it looks the same as when tested in Chrome.


## Visual Regressions
The repo does not use a visual regression testing system.


## Relevant Screenshots/GIFs
![image](https://user-images.githubusercontent.com/4438120/52238880-bb0c6a00-2892-11e9-9478-954a6d07e5ae.png)


## Remaining Tasks
N/A


## Additional Notes
N/A
