### PR TITLE
EWLJ-324: Change line height around superscripts

### DIFF
--- a/styleguide/source/assets/scss/00-base/_typography.scss
+++ b/styleguide/source/assets/scss/00-base/_typography.scss
@@ -80,3 +80,9 @@ p,
     overflow: auto;
   }
 }
+
+sup {
+  position: relative;
+  line-height: 1;
+  font-size: $base-font-size * 0.8;
+}

--- a/styleguide/source/assets/scss/05-pages/_article.scss
+++ b/styleguide/source/assets/scss/05-pages/_article.scss
@@ -40,6 +40,7 @@
 }
 
 sup {
-  vertical-align: top;
-  font-size: 0.8em;
+  vertical-align: 0;
+  position: relative;
+  bottom: 0.5em;
 }

--- a/styleguide/source/assets/scss/05-pages/_article.scss
+++ b/styleguide/source/assets/scss/05-pages/_article.scss
@@ -34,3 +34,7 @@
   @include gutter($margin-bottom-full...);
   background-color: $white;
 }
+
+.joe__page-content--article {
+  padding-top: 5px;
+}

--- a/styleguide/source/assets/scss/05-pages/_article.scss
+++ b/styleguide/source/assets/scss/05-pages/_article.scss
@@ -38,9 +38,3 @@
 .joe__page-content--article {
   padding-top: 5px;
 }
-
-sup {
-  vertical-align: 0;
-  position: relative;
-  bottom: 0.5em;
-}

--- a/styleguide/source/assets/scss/05-pages/_article.scss
+++ b/styleguide/source/assets/scss/05-pages/_article.scss
@@ -38,3 +38,8 @@
 .joe__page-content--article {
   padding-top: 5px;
 }
+
+sup {
+  vertical-align: top;
+  font-size: 0.8em;
+}


### PR DESCRIPTION
**Jira Ticket**

- [EWLJ-324: Change line height around superscripts](https://issues.ama-assn.org/browse/EWLJ-324)


## Description

Adds styling in order to fix the line height between lines with superscripts and lines without.

## To Test

- [ ] run `gulp serve`
- [ ] enable local SG2 testing in your D8 env
- [ ] in your D8 instance run `drush @joe.local cr`
- [ ] navigate to a page like (http://ama-joe.local/article/immigration-daca-and-health-care/2019-01) and check that the line height between the body lines that have superscripts are the same with the ones that don't have superscripts.
- [ ] This PR adds padding between the body and the `References` paragraph to match the styleguide.

## Visual Regressions 

N/A


## Relevant Screenshots/GIFs

**Before** 
![image](https://user-images.githubusercontent.com/17749755/52484579-48460c00-2b7c-11e9-8f28-6723971fa7a5.png)

**After**
![image](https://user-images.githubusercontent.com/17749755/52501660-76d8dc80-2ba6-11e9-981b-25b4f4c601e7.png)



## Remaining Tasks

N/A


## Additional Notes

N/A
