### PR TITLE
EWLJ-332: increase share icons size to 31px

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_share.scss
+++ b/styleguide/source/assets/scss/02-molecules/_share.scss
@@ -127,13 +127,13 @@
     margin: 0;
 
     .joe__icon {
-      height: 25px;
-      width: 25px;
+      height: 31px;
+      width: 31px;
     }
 
     svg {
-      height: 25px;
-      width: 25px;
+      height: 31px;
+      width: 31px;
     }
 
     svg {


### PR DESCRIPTION
**Jira Ticket**

- [EWLJ-332: increase social media icon sizes](https://issues.ama-assn.org/browse/EWLJ-332)


## Description

Increase media share icon sizes to 31px, the same size as ama-one.

## To Test

- [ ] run `gulp serve`
- [ ] enable local SG2 testing in your D8 env
- [ ] in your D8 instance run `drush @joe.local cr`
- [ ] Navigate to a page like (http://ama-joe.local/article/can-ai-help-reduce-disparities-general-medical-and-mental-health-care/2019-02) and check the new size of the share icons. Inspect and check the size, provide feedback if we need to increase them even more.

## Visual Regressions

N/A


## Relevant Screenshots/GIFs

N/A

## Remaining Tasks

N/A


## Additional Notes

N/A
