### PR TITLE
EWLJ-338 Adds reference tooltip

### DIFF
--- a/styleguide/build.config.json
+++ b/styleguide/build.config.json
@@ -37,6 +37,7 @@
       "source/assets/js/init.js",
       "source/assets/js/form-items.js",
       "source/assets/js/nav.js",
+      "source/assets/js/resource-tooltips.js",
       "source/_patterns/**/*.js"
     ],
     "dest"  : "public/assets/js/"

--- a/styleguide/source/_meta/_01-foot.twig
+++ b/styleguide/source/_meta/_01-foot.twig
@@ -14,6 +14,7 @@
 <script src="../../assets/js/issueFilters.js"></script>
 <script src="../../assets/js/poll-reveal.js"></script>
 <script src="../../assets/js/lightbox.js"></script>
+<script src="../../assets/js/resource-tooltips.js"></script>
 {# Modernizr #}
 {# Contains: cssgrid, css animations, flexbox #}
 <script src="../../assets/js/modernizr-custom.js"></script>

--- a/styleguide/source/assets/js/resource-tooltips.js
+++ b/styleguide/source/assets/js/resource-tooltips.js
@@ -1,0 +1,35 @@
+/**
+ * @file
+ * Ribbon nav user interactions.
+ *
+ * JavaScript should be made compatible with libraries other than jQuery by
+ * wrapping it with an "anonymous closure". See:
+ * - https://drupal.org/node/1446420
+ * - http://www.adequatelygood.com/2010/3/JavaScript-Module-Pattern-In-Depth
+ */
+ (function ($, Drupal) {
+   Drupal.behaviors.resourceToolips = {
+     attach: function (context, settings) {
+       $('article p sup').hover(
+         function() {
+           // Find the <sup> tag number and convert it into an integer
+           var $supNumber = parseInt($(this).text()) - 1;
+           // Take <sup> number and use it to get the reference
+           var $reference = $('.joe__references__list li').eq($supNumber);
+           // Prevent the hover function from cloning the reference more than once
+           if(!$(this).find('.ama__tooltip').length){
+             // Append a div with the reference to the <sup>
+             $(this).append('<div class="ama__tooltip">' + $reference.html() + '</div>');
+             // Show the reference tooltip
+             $(this).children('.ama__tooltip').fadeIn()
+           } else {
+             $(this).find('.ama__tooltip').fadeIn();
+           }
+         }, function() {
+           // Hide reference tooltip
+           $(this).find('.ama__tooltip').fadeOut();
+         }
+       );
+     }
+   };
+ })(jQuery, Drupal);

--- a/styleguide/source/assets/js/resource-tooltips.js
+++ b/styleguide/source/assets/js/resource-tooltips.js
@@ -10,7 +10,7 @@
  (function ($, Drupal) {
    Drupal.behaviors.resourceToolips = {
      attach: function (context, settings) {
-       $('article p sup').hover(
+       $('article sup').hover(
          function() {
            // Find the <sup> tag number and convert it into an integer
            var $supNumber = parseInt($(this).text()) - 1;

--- a/styleguide/source/assets/scss/00-base/_typography.scss
+++ b/styleguide/source/assets/scss/00-base/_typography.scss
@@ -80,3 +80,11 @@ p,
     overflow: auto;
   }
 }
+
+sup {
+  position: relative;
+
+  &:hover {
+    cursor: pointer;
+  }
+}

--- a/styleguide/source/assets/scss/01-atoms/_tooltip.scss
+++ b/styleguide/source/assets/scss/01-atoms/_tooltip.scss
@@ -11,5 +11,5 @@
   z-index: 10;
   left: 0;
   top: 0;
-  word-break: break-word;
+  word-break: break-all;
 }

--- a/styleguide/source/assets/scss/01-atoms/_tooltip.scss
+++ b/styleguide/source/assets/scss/01-atoms/_tooltip.scss
@@ -1,0 +1,15 @@
+.ama__tooltip {
+  box-shadow: $shadow;
+  padding: $gutter / 2;
+  border-top: 1px solid $black-05;
+  border-left: 1px solid $black-05;
+  border-right: 1px solid $black-05;
+  display: none;
+  position: absolute;
+  background: $white;
+  min-width: 250px;
+  z-index: 10;
+  left: 0;
+  top: 0;
+  word-break: break-word;
+}


### PR DESCRIPTION
## Ticket(s)

**Jira Ticket**

- [EWLJ-338: SG | Design popup references to articles](https://issues.ama-assn.org/browse/EWLJ-338)


## Description

Add tooltips to article <sup> tags using reference information below the article.

## To Test
- [ ] switch your JOE styleguide branch to `feature/EWLJ-338-popup-reference-articles`
- [ ] run `gulp serve`
- [ ] switch your D8 branch to `feature/EWLJ-338-popup-reference-articles`
- [ ] enable local JOE styleguide development in your local.yml file in D8
- [ ] run `scripts/build` outside of your vagrant
- [ ] `vagrant ssh` > `drush @joe.local cr`
- [ ] visit http://ama-joe.local/article/making-policy-augmented-intelligence-health-care/2019-02
- [ ] hover over a superscript text with a number in it
- [ ] observe a tooltip appears with the relevant reference in it 

## Visual Regressions
The repo does not use a visual regression testing system.

## Relevant Screenshots/GIFs

![screen shot 2019-02-05 at 3 24 35 pm](https://user-images.githubusercontent.com/2271747/52305192-2a995c80-295a-11e9-9722-b5d805773c39.png)


## Remaining Tasks

n/a


## Additional Notes

n/a