### PR TITLE
EWLJ-316: Ethics polls buttons should look the same as style guide

### DIFF
--- a/styleguide/build.config.json
+++ b/styleguide/build.config.json
@@ -37,6 +37,7 @@
       "source/assets/js/init.js",
       "source/assets/js/form-items.js",
       "source/assets/js/nav.js",
+      "source/assets/js/poll-reveal.js",
       "source/_patterns/**/*.js"
     ],
     "dest"  : "public/assets/js/"

--- a/styleguide/source/assets/js/poll-reveal.js
+++ b/styleguide/source/assets/js/poll-reveal.js
@@ -7,20 +7,44 @@
  * - https://drupal.org/node/1446420
  * - http://www.adequatelygood.com/2010/3/JavaScript-Module-Pattern-In-Depth
  */
- (function ($, Drupal) {
-   Drupal.behaviors.pollReveal = {
-     attach: function (context, settings) {
-        // Opens and closes results. 
-        $('.joe__poll__reveal').click(function(e) {
-          e.preventDefault();
-          e.stopPropagation();
-          // Unfocus on the dropdown
-          $(this).blur();
-          // add a class to the sibling dropdown
-          $(this).parents('.joe__poll__answers').toggleClass('is-open');
-          $(this).toggleClass('is-active'); 
-        });
+(function ($, Drupal) {
+  Drupal.behaviors.pollReveal = {
+    attach: function (context, settings) {
+      // Opens and closes results. 
+      $(document).ready(function () {
+        $('.joe__poll__reveal').unbind('click').bind('click', (function (event) {
+        console.log('test');
+        // Prevents the default event behavior (ie: click).
+        event.preventDefault();
+        // Prevents the event from propagating (ie: "bubbling").
+        event.stopPropagation();
+        // Unfocus on the dropdown
+        $(this).blur();
+        // add a class to the sibling dropdown  
+        $(this).parents('.joe__poll__answers').toggleClass('is-open');
+        $(this).toggleClass('is-active');
+      }));
+    });
+   }
+  }
+})(jQuery, Drupal);
 
-     }
-   };
- })(jQuery, Drupal);
+// (function ($, Drupal) {
+//   Drupal.behaviors.pollReveal = {
+//     attach: function (context, settings) {
+//  
+//       $('.joe__poll__reveal', context).once('pollReveal').unbind('click').bind('click', (function (event) {
+//           console.log('test');
+//           // Prevents the default event behavior (ie: click).
+//           event.preventDefault();
+//           // Prevents the event from propagating (ie: "bubbling").
+//           event.stopPropagation();
+//           // Unfocus on the dropdown
+//           $(this).blur();
+//           // add a class to the sibling dropdown  
+//           $(this).parents('.joe__poll__answers').toggleClass('is-open');
+//           $(this).toggleClass('is-active');
+//         }));
+//     }
+//   }
+// })(jQuery, Drupal);

--- a/styleguide/source/assets/js/poll-reveal.js
+++ b/styleguide/source/assets/js/poll-reveal.js
@@ -17,13 +17,18 @@
           event.preventDefault();
           // Prevents the event from propagating (ie: "bubbling").
           event.stopPropagation();
-          // console.log('test');
           // Unfocus on the dropdown
         $(this).blur();
         // add a class to the sibling dropdown  
         $(this).parents('.joe__poll__answers').toggleClass('is-open');
         $(this).toggleClass('is-active');
       }));
+      // Updates show/hide text. 
+      $('.joe__poll__answers').each(function(i, obj) {
+          if($(this).is(".is-open")){
+	          $(this).find('.joe__poll__reveal').addClass('is-active');
+          }
+      });
     });
    }
   }

--- a/styleguide/source/assets/js/poll-reveal.js
+++ b/styleguide/source/assets/js/poll-reveal.js
@@ -13,12 +13,12 @@
       // Opens and closes results. 
       $(document).ready(function () {
         $('.joe__poll__reveal').unbind('click').bind('click', (function (event) {
-        console.log('test');
-        // Prevents the default event behavior (ie: click).
-        event.preventDefault();
-        // Prevents the event from propagating (ie: "bubbling").
-        event.stopPropagation();
-        // Unfocus on the dropdown
+          // Prevents the default event behavior (ie: click).
+          event.preventDefault();
+          // Prevents the event from propagating (ie: "bubbling").
+          event.stopPropagation();
+          // console.log('test');
+          // Unfocus on the dropdown
         $(this).blur();
         // add a class to the sibling dropdown  
         $(this).parents('.joe__poll__answers').toggleClass('is-open');
@@ -28,23 +28,3 @@
    }
   }
 })(jQuery, Drupal);
-
-// (function ($, Drupal) {
-//   Drupal.behaviors.pollReveal = {
-//     attach: function (context, settings) {
-//  
-//       $('.joe__poll__reveal', context).once('pollReveal').unbind('click').bind('click', (function (event) {
-//           console.log('test');
-//           // Prevents the default event behavior (ie: click).
-//           event.preventDefault();
-//           // Prevents the event from propagating (ie: "bubbling").
-//           event.stopPropagation();
-//           // Unfocus on the dropdown
-//           $(this).blur();
-//           // add a class to the sibling dropdown  
-//           $(this).parents('.joe__poll__answers').toggleClass('is-open');
-//           $(this).toggleClass('is-active');
-//         }));
-//     }
-//   }
-// })(jQuery, Drupal);

--- a/styleguide/source/assets/js/poll-reveal.js
+++ b/styleguide/source/assets/js/poll-reveal.js
@@ -23,7 +23,7 @@
         $(this).parents('.joe__poll__answers').toggleClass('is-open');
         $(this).toggleClass('is-active');
       }));
-      // Updates show/hide text. 
+      // Updates show/hide text.
       $('.joe__poll__answers').each(function(i, obj) {
           if($(this).is(".is-open")){
 	          $(this).find('.joe__poll__reveal').addClass('is-active');

--- a/styleguide/source/assets/scss/03-organisms/_poll.scss
+++ b/styleguide/source/assets/scss/03-organisms/_poll.scss
@@ -121,6 +121,8 @@
 .joe__poll__reveal,
 .joe__poll__reveal[type='submit'] {
   @extend %joe__type--small;
+  margin-left: .5em;
+  display: inline;
   background-color: none;
   background: none;
   border-radius: 0;


### PR DESCRIPTION
## JIRA Ticket(s)
- [EWLJ-316: Ethics polls buttons should look the same as style guide](https://issues.ama-assn.org/browse/EWLJ-316)


## Description:
- Adds the appropriate classes do the buttons in order to match the styleguide.
- Adds styling for button and show/hide text

## To Test:
- [ ] run `gulp serve`
- [ ] enable local SG2 testing in your D8 env
- [ ] in your D8 instance run `drush @joe.local cr`
- [ ] Navigate to (http://ama-joe.local/home) and check that the styling of the buttons on the poll forms  matches the styleguide(http://localhost:3002/?p=organisms-poll--structured)


## Automated Test:
N/A


## Style Guide:
N/A


## Relevant Screenshots/GIFs:
N/A


## Additional Notes:
Anything more to add?


---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)
