### PR TITLE
EWLJ-345 email sign up design

### DIFF
--- a/styleguide/source/_patterns/02-molecules/rail-cta.twig
+++ b/styleguide/source/_patterns/02-molecules/rail-cta.twig
@@ -1,4 +1,4 @@
-<aside class="joe__rail-cta">
+<aside class="joe__rail-cta {% if rail_cta.secondary == true %}joe__rail-cta--secondary{% endif %}">
   {% set heading = rail_cta.heading %}
   {% include "heading.twig" %}
   <div class="joe__rail-cta__text">

--- a/styleguide/source/_patterns/02-molecules/rail-cta~secondary.json
+++ b/styleguide/source/_patterns/02-molecules/rail-cta~secondary.json
@@ -1,0 +1,20 @@
+{
+  "rail_cta": { 
+    "secondary": true,
+    "heading": {
+      "level": "3",
+      "text": "Join the Discussion",
+      "class": "joe__rail-cta__title"
+    },
+    "paragraph" : {
+      "text": "Our Discussion Forum provides an opportunity for students, educators, and clinicians to engage experts in an online conversation about important ethical issues in health care."
+    },
+    "button": {
+      "href": "#",
+      "info": "alt",
+      "text": "Discussion Forum",
+      "type": "link",
+      "size": "small"
+    }
+  }
+}

--- a/styleguide/source/_patterns/02-molecules/rail-form.json
+++ b/styleguide/source/_patterns/02-molecules/rail-form.json
@@ -1,0 +1,32 @@
+{
+  "rail_form": { 
+    "heading": {
+      "level": "3",
+      "text": "Stay Up-to-Date",
+      "class": "joe__rail-cta__title"
+    },
+    "paragraph" : {
+      "text": "Receive email updates when we publish our monthly issue."
+    },
+    "label": {
+      "id": "newsletterEmail",
+      "text": "Email"
+    },
+    "emailinput": {
+      "type": "email",
+      "name": "Newsletter Email",
+      "id": "newsletterEmail",
+      "value": null,
+      "placeholder": null,
+      "class": "joe__rail-form__input"
+    },
+    "formsubmit": {
+      "type": "submit",
+      "name": "Newsletter Form Submit",
+      "id": "newsletter-submit",
+      "value": "Subscribe",
+      "placeholder": null,
+      "class": "joe__button joe__button--small joe__rail-form__submit"
+    }
+  }
+}

--- a/styleguide/source/_patterns/02-molecules/rail-form.md
+++ b/styleguide/source/_patterns/02-molecules/rail-form.md
@@ -1,0 +1,28 @@
+### Description
+This Pattern shows the rail form for newsletter sign-ups.
+
+### Variables
+~~~
+rail_form {
+  secondary:
+    type: boolean / required
+  heading.text:
+    type: string / required
+  paragraph.text:
+    type: string / required
+  label.id:
+    type: string / required
+  label.text:
+    type: string / required
+  emailinput.name:
+    type: string / required
+  emailinput.id:
+    type: string / required
+  formsubmit.name:
+    type: string / required
+  formsubmit.id:
+    type: string / required
+  formsubmit.value:
+    type: string / required
+}
+~~~

--- a/styleguide/source/_patterns/02-molecules/rail-form.twig
+++ b/styleguide/source/_patterns/02-molecules/rail-form.twig
@@ -1,0 +1,17 @@
+<aside class="joe__rail-cta {% if rail_form.secondary == true %}joe__rail-cta--secondary{% endif %}">
+  {% set heading = rail_form.heading %}
+  {% include "heading.twig" %}
+  <div class="joe__rail-cta__text">
+    {% set paragraph = rail_form.paragraph %}
+    {% include "paragraph.twig" %}
+  </div>
+  <form class="joe__rail-form__form">
+    {% set label = rail_form.label %}
+    {% include "label.twig" %}
+    {% set input = rail_form.emailinput %}
+    {% include "input.twig" %}
+    {% set input = rail_form.formsubmit %}
+    {% include "input.twig" %}
+  </form>
+ 
+</aside>

--- a/styleguide/source/_patterns/02-molecules/rail-form~secondary.json
+++ b/styleguide/source/_patterns/02-molecules/rail-form~secondary.json
@@ -1,0 +1,33 @@
+{
+  "rail_form": { 
+    "secondary": true,
+    "heading": {
+      "level": "3",
+      "text": "Stay Up-to-Date",
+      "class": "joe__rail-cta__title"
+    },
+    "paragraph" : {
+      "text": "Receive email updates when we publish our monthly issue."
+    },
+    "label": {
+      "id": "newsletterEmail",
+      "text": "Email"
+    },
+    "emailinput": {
+      "type": "email",
+      "name": "Newsletter Email",
+      "id": "newsletterEmail",
+      "value": null,
+      "placeholder": null,
+      "class": "joe__rail-form__input"
+    },
+    "formsubmit": {
+      "type": "submit",
+      "name": "Newsletter Form Submit",
+      "id": "newsletter-submit",
+      "value": "Subscribe",
+      "placeholder": null,
+      "class": "joe__button joe__button--small joe__rail-form__submit"
+    }
+  }
+}

--- a/styleguide/source/_patterns/03-organisms/cta-band.json
+++ b/styleguide/source/_patterns/03-organisms/cta-band.json
@@ -52,21 +52,35 @@
       }
     },
     { 
+      "form": true,
       "heading": {
         "level": "3",
-        "text": "Stay Up-to-date",
+        "text": "Stay Up-to-Date",
         "class": "joe__rail-cta__title"
       },
       "paragraph" : {
-        "text": "Never miss an issue again, sign up for our newsletters to be alerted each time we publish a new issue."
+        "text": "Receive email updates when we publish our monthly issue."
       },
-      "button": {
-        "href": "#",
-        "info": "alt",
-        "text": "Subscribe",
-        "type": "link",
-        "size": "small"
+      "label": {
+        "id": "newsletterEmail",
+        "text": "Email"
+      },
+      "emailinput": {
+        "type": "email",
+        "name": "Newsletter Email",
+        "id": "newsletterEmail",
+        "value": null,
+        "placeholder": null,
+        "class": "joe__rail-form__input"
+      },
+      "formsubmit": {
+        "type": "submit",
+        "name": "Newsletter Form Submit",
+        "id": "newsletter-submit",
+        "value": "Subscribe",
+        "placeholder": null,
+        "class": "joe__button joe__button--small joe__rail-form__submit"
       }
-    } 
+    }
   ]
 }

--- a/styleguide/source/_patterns/03-organisms/cta-band.twig
+++ b/styleguide/source/_patterns/03-organisms/cta-band.twig
@@ -3,8 +3,13 @@
 
     <ul class="joe__cta-band__list">
     {% for cta in ctas %}
-      {% set rail_cta = cta %}
-      <li>{% include '@molecules/rail-cta.twig' %}</li>
+      {% if cta.form == true %}
+        {% set rail_form = cta %}
+        <li>{% include '@molecules/rail-form.twig' %}</li>
+      {% else %}
+        {% set rail_cta = cta %}
+        <li>{% include '@molecules/rail-cta.twig' %}</li>
+      {% endif %}
     {% endfor %}
     </ul>
   </div>

--- a/styleguide/source/_patterns/05-pages/article--no-image.json
+++ b/styleguide/source/_patterns/05-pages/article--no-image.json
@@ -470,6 +470,37 @@
       }
     ]
   },
+  "rail_form": { 
+    "secondary": true,
+    "heading": {
+      "level": "3",
+      "text": "Stay Up-to-Date",
+      "class": "joe__rail-cta__title"
+    },
+    "paragraph" : {
+      "text": "Receive email updates when we publish our monthly issue."
+    },
+    "label": {
+      "id": "newsletterEmail",
+      "text": "Email"
+    },
+    "emailinput": {
+      "type": "email",
+      "name": "Newsletter Email",
+      "id": "newsletterEmail",
+      "value": null,
+      "placeholder": null,
+      "class": "joe__rail-form__input"
+    },
+    "formsubmit": {
+      "type": "submit",
+      "name": "Newsletter Form Submit",
+      "id": "newsletter-submit",
+      "value": "Subscribe",
+      "placeholder": null,
+      "class": "joe__button joe__button--small joe__rail-form__submit"
+    }
+  },
   "rail_cta": { 
     "heading": {
       "level": "3",

--- a/styleguide/source/_patterns/05-pages/article--no-image.twig
+++ b/styleguide/source/_patterns/05-pages/article--no-image.twig
@@ -20,8 +20,6 @@
   
   <p>One response to these challenges has been calls for the co-creation of health care systems. Co-creation can take a number of different forms, but at heart it represents bringing together key stakeholders to jointly address problems [3]. In medicine, health professionals, patients, providers, and other stakeholders can be involved in co-creation initiatives including achieving professional-patient concordance through shared decision making, personalization of health services, patient self-management or self-care, and interprofessional or interagency collaboration (e.g., among physicians, nurses, dieticians, podiatrists, and a variety of allied health professionals in caring for patients with diabetes) [4]. Co-creation in medicine typically seeks to extend the role of patients or service users in clinical settings and beyond by encouraging their participation in care processes or service design [4]. It can enable service users to exercise voice and choice and to take up new roles and responsibilities. For instance, in the context of the UK National Health Service, patients with chronic conditions are encouraged to assume “self-management” roles that involve taking responsibility for decision making, administering self-care, and even managing a personal health care budget [5]. Co-creation can also entail broad structural changes, such as partnerships that span clinical or institutional boundaries [3], including those in which health professionals of different stripes are brought together to work with public sector professionals or community stakeholders.</p>
   
-  {% include "@organisms/poll.twig" %}
-  
   <p>Although co-creation presents opportunities to develop more responsive, integrated, and outward-looking health care systems [6], realizing co-creation in practice means confronting significant professional, political, and ethical challenges. In this paper, we seek to promote critical reflection about some of these challenges. We argue that for co-creation to be successful, these challenges must be recognized, by clinicians in particular, and then negotiated as best as possible.</p>
 
   <h2>Common Ground in Diverse Contexts?</h2>
@@ -35,6 +33,8 @@
 
   <p>Thus what matters most for co-creative health systems should be decided with reference to local views and circumstances rather than abstract or universal principles. With this in mind, co-creation should rightly involve bringing local citizens, patients, health care practitioners, policymakers, and other stakeholders together to discuss the dilemmas inherent to processes of agenda setting in health care. Throughout these discussions, sensitivity to divergent interests and perspectives will be key to building a consensus.</p>
 
+  {% include "@organisms/poll.twig" %}
+  
   <h3>Challenges of Changing Professional Roles</h3>
   <p>Having examined the difficulties involved in finding a consensus upon which to base co-creation initiatives, we now consider some of the broader challenges associated with implementing co-creation in practice.</p>
 
@@ -64,6 +64,7 @@
 {% endblock %}
 
 {% block sidebar_top %}
+  {% include "@molecules/rail-form.twig" %}
   {% include "@molecules/rail-cta.twig" %}
   
   {% include "@organisms/related-articles.twig" %}

--- a/styleguide/source/_patterns/05-pages/homepage.json
+++ b/styleguide/source/_patterns/05-pages/homepage.json
@@ -470,20 +470,34 @@
       }
     },
     { 
+      "form": true,
       "heading": {
         "level": "3",
-        "text": "Stay Up-to-date",
+        "text": "Stay Up-to-Date",
         "class": "joe__rail-cta__title"
       },
       "paragraph" : {
-        "text": "Never miss an issue again, sign up for our newsletters to be alerted each time we publish a new issue."
+        "text": "Receive email updates when we publish our monthly issue."
       },
-      "button": {
-        "href": "#",
-        "info": "alt",
-        "text": "Subscribe",
-        "type": "link",
-        "size": "small"
+      "label": {
+        "id": "newsletterEmail",
+        "text": "Email"
+      },
+      "emailinput": {
+        "type": "email",
+        "name": "Newsletter Email",
+        "id": "newsletterEmail",
+        "value": null,
+        "placeholder": null,
+        "class": "joe__rail-form__input"
+      },
+      "formsubmit": {
+        "type": "submit",
+        "name": "Newsletter Form Submit",
+        "id": "newsletter-submit",
+        "value": "Subscribe",
+        "placeholder": null,
+        "class": "joe__button joe__button--small joe__rail-form__submit"
       }
     }
   ],

--- a/styleguide/source/assets/scss/01-atoms/_button.scss
+++ b/styleguide/source/assets/scss/01-atoms/_button.scss
@@ -31,7 +31,8 @@ button {
 }
 
 %joe__button--small,
-.joe__button--small {
+.joe__button--small,
+.joe__button--small[type="submit"] {
   @include type($font-serif, .75em, $font-weight-bold, 1.25);
   padding: 8px 18px;
 }

--- a/styleguide/source/assets/scss/02-molecules/_rail-cta.scss
+++ b/styleguide/source/assets/scss/02-molecules/_rail-cta.scss
@@ -22,3 +22,27 @@
   @extend %joe__type--small;
   margin-bottom: 1em;
 }
+
+.joe__rail-cta--secondary {
+  background-color: transparent;
+  background: $blue-gradient;
+  
+  .joe__rail-cta__title,
+  .joe__rail-cta__text {
+    color: $white;
+  }
+  
+  .joe__button,
+  .joe__button[type="submit"] {
+    background-color: $gold;
+    background: $gold;
+    color: $navy;
+    
+    &:active,
+    &:hover,
+    &:focus {
+      background-color: $orange;
+      background: $orange;
+    }
+  }
+}

--- a/styleguide/source/assets/scss/02-molecules/_rail-form.scss
+++ b/styleguide/source/assets/scss/02-molecules/_rail-form.scss
@@ -1,0 +1,15 @@
+.joe__rail-cta--secondary {
+
+  .joe__rail-form__form label {
+    color: $white;
+  }
+  
+  .joe__rail-form__form {
+    border-color: rgba($white, .25);
+  }
+}
+
+.joe__rail-form__form {
+  border-top: 1px solid $black-20;
+  padding-top: .5em;
+}

--- a/styleguide/source/assets/scss/02-molecules/_rail-form.scss
+++ b/styleguide/source/assets/scss/02-molecules/_rail-form.scss
@@ -3,13 +3,8 @@
   .joe__rail-form__form label {
     color: $white;
   }
-  
-  .joe__rail-form__form {
-    border-color: rgba($white, .25);
-  }
 }
 
 .joe__rail-form__form {
-  border-top: 1px solid $black-20;
-  padding-top: .5em;
+  padding-top: .25em;
 }

--- a/styleguide/source/assets/scss/03-organisms/_cta-band.scss
+++ b/styleguide/source/assets/scss/03-organisms/_cta-band.scss
@@ -26,6 +26,10 @@
       float: flex;
       overflow: hidden;
       
+      .joe__rail-cta  {
+        height: 100%;
+      }
+      
       // 1-up layout
       // when there is one item it's full width
       &:nth-child(1):nth-last-child(1) {


### PR DESCRIPTION
## Ticket(s)

**Github Issue**
n/A

**Jira Ticket**

- [EWLJ-345: Email Sign Up Design](https://issues.ama-assn.org/browse/EWLJ-345)
- [EWLJ-337: Ability to have more than one CTA box.](https://issues.ama-assn.org/browse/EWLJ-337)


## Description

Creation of a secondary CTA design style (rail cta secondary) as well as a rail form molecule with default and secondary styles.

This work created:

- Rail CTA Secondary Molecule
- Rail Form Molecule
- Rail Form Secondary Molecule.

This work modified:
- Article No Image Page (rail)
- Homepage Page (cta band)
- CTA Band Organism

## To Test

- [ ] Build the styleguide locally.
- [ ] Review the Rail CTA Secondary Molecule for markup, styles, responsiveness, and accessibility.
- [ ] Review the Rail Form Molecule for markup, styles, responsiveness, and accessibility.
- [ ] Review the Rail Form Secondary Molecule for markup, styles, responsiveness, and accessibility.
- [ ] Review the CTA Band Organism.
- [ ] Review the Article No Image Page, verify that there are more than one CTA boxes on the page.
- [ ] Review the Homepage Page.

## Visual Regressions

N/A

## Relevant Screenshots/GIFs

The following Screenshots were approved by the JoE Team with the note to remove the rule.

![form-style](https://user-images.githubusercontent.com/4439057/54698577-892b2c00-4afd-11e9-88d1-2236ff59cb18.png)
![Uploading secondary-form-style.png…]()
![Uploading Secondary-cta-style.png…]()


## Remaining Tasks

N/A

## Additional Notes

N/A
