### PR TITLE
EWLJ-334 topic tag adjustments

### DIFF
--- a/styleguide/source/_patterns/02-molecules/tags-list.twig
+++ b/styleguide/source/_patterns/02-molecules/tags-list.twig
@@ -1,4 +1,5 @@
 <div class="joe__tags">
+  <h2 class="joe__tags-title">Read More</h2>
   <ul class="joe__tags-list">
     {% for tag in tags %}
       {% if loop.last %}

--- a/styleguide/source/_patterns/02-molecules/tags-list.twig
+++ b/styleguide/source/_patterns/02-molecules/tags-list.twig
@@ -1,5 +1,4 @@
 <div class="joe__tags">
-  {% include "icon.twig" with { "icon": {"symbol": "tag", "text": "tags"} } %}
   <ul class="joe__tags-list">
     {% for tag in tags %}
       {% if loop.last %}

--- a/styleguide/source/_patterns/05-pages/article--no-image.json
+++ b/styleguide/source/_patterns/05-pages/article--no-image.json
@@ -227,23 +227,23 @@
   "tags": [
     {
       "url": "#",
-      "text": "Access to Care"
+      "text": "Abuse/Child or Elder Abuse"
     },
     {
       "url": "#",
-      "text": "Conflict of Interest"
+      "text": "Access to Care/Gender or Gender Transition Barriers"
     },
     {
       "url": "#",
-      "text": "Contract with Society"
+      "text": "Autonomy/Capacity, competency for making decisions"
     },
     {
       "url": "#",
-      "text": "Cost of Care"
+      "text": "Confidentiality/Duty to protect confidential information"
     },
     {
       "url": "#",
-      "text": "Human Rights"
+      "text": "Clinical Research/Vulnerable populations"
     }
   ],
   "references": [

--- a/styleguide/source/_patterns/05-pages/article--no-image.twig
+++ b/styleguide/source/_patterns/05-pages/article--no-image.twig
@@ -55,8 +55,10 @@
 {% endblock %}
 
 {% block pageContent_footer %}
-  {% include "@molecules/references.twig" %}
   {% include "@molecules/tags-list.twig" %}
+  
+  {% include "@molecules/references.twig" %}
+  
   {% include "@organisms/article-footer.twig" %}
   
   {% set authors = article_authors %}

--- a/styleguide/source/_patterns/05-pages/article--no-image.twig
+++ b/styleguide/source/_patterns/05-pages/article--no-image.twig
@@ -56,23 +56,18 @@
 
 {% block pageContent_footer %}
   {% include "@molecules/tags-list.twig" %}
-  
   {% include "@molecules/references.twig" %}
-  
   {% include "@organisms/article-footer.twig" %}
-  
   {% set authors = article_authors %}
   {% include "@molecules/author-information.twig" %}
 {% endblock %}
 
 {% block sidebar_top %}
   {% include "@molecules/rail-cta.twig" %}
-  
   {% include "@organisms/related-articles.twig" %}
 {% endblock %}
 
 {% block footer %}
   {% include "@organisms/article-issue-footer.twig" %}
-  
   {% include '@organisms/footer.twig' %}
 {% endblock %}

--- a/styleguide/source/_patterns/05-pages/article.twig
+++ b/styleguide/source/_patterns/05-pages/article.twig
@@ -59,8 +59,10 @@
 {% endblock %}
 
 {% block pageContent_footer %}
-  {% include "@molecules/references.twig" %}
   {% include "@molecules/tags-list.twig" %}
+  
+  {% include "@molecules/references.twig" %}
+  
   {% include "@organisms/article-footer.twig" %}
   
   {% set authors = article_authors %}

--- a/styleguide/source/_patterns/05-pages/article.twig
+++ b/styleguide/source/_patterns/05-pages/article.twig
@@ -60,23 +60,18 @@
 
 {% block pageContent_footer %}
   {% include "@molecules/tags-list.twig" %}
-  
   {% include "@molecules/references.twig" %}
-  
   {% include "@organisms/article-footer.twig" %}
-  
   {% set authors = article_authors %}
   {% include "@molecules/author-information.twig" %}
 {% endblock %}
 
 {% block sidebar_top %}
   {% include "@molecules/rail-cta.twig" %}
-
   {% include "@organisms/related-articles.twig" %}
 {% endblock %}
 
 {% block footer %}
   {% include "@organisms/article-issue-footer.twig" %}
-  
   {% include '@organisms/footer.twig' %}
 {% endblock %}

--- a/styleguide/source/assets/scss/02-molecules/_tags-list.scss
+++ b/styleguide/source/assets/scss/02-molecules/_tags-list.scss
@@ -34,6 +34,7 @@
     display: inline;
     color: $orange-darker;
     margin-bottom: .35em;
+    padding: 0 2px;
     border-bottom: 2px solid $orange-darker;
   }
   

--- a/styleguide/source/assets/scss/02-molecules/_tags-list.scss
+++ b/styleguide/source/assets/scss/02-molecules/_tags-list.scss
@@ -1,6 +1,5 @@
 .joe__tags-title {
   @include type($font-serif, .65em, $font-weight-medium, 1.25);
-  display: inline;
   text-transform: uppercase;
   font-weight: 700;
   margin-right: .5em;

--- a/styleguide/source/assets/scss/02-molecules/_tags-list.scss
+++ b/styleguide/source/assets/scss/02-molecules/_tags-list.scss
@@ -1,52 +1,48 @@
+.joe__tags-title {
+  @include type($font-serif, .65em, $font-weight-medium, 1.25);
+  display: inline;
+  text-transform: uppercase;
+  font-weight: 700;
+  margin-right: .5em;
+}
+
 .joe__tags {
-  @extend %joe__type--small;
   position: relative;
-  margin: $gutter 0;
-  padding: 1em 0 0 40px;
+  margin: 1em 0 3em;
+  padding: 2em 0 3em;
   clear: both;
 
-  border-top: 1px solid $black-20;
-  
-  .icon-tag {
-    height: 1em;
-    width: 1em;
-    position: absolute;
-    left: 9px;
-    top: 1.2em;
-    
-    svg {
-      height: 1em;
-      width: 1em;
-      fill: $black-80;
-    }
-  }
+  border-bottom: 1px solid $black-20;
   
   @include breakpoint($bp-med) {
-    padding: 1em 0 0 40px;
+    padding: 2em 0;
   }
 }
 
 .joe__tags-list {
+  @extend %joe__type--smaller;
   list-style: none;
   margin: 0;
   padding: 0;
 }
 
 .joe__tag {
-  display: inline-block;
-  text-transform: none;
+  display: inline;
   letter-spacing: 0;
-  color: $black-80;
   
   a:link,
   a:visited {
-    color: $black-80;
-    border-bottom: 0;
+    display: inline;
+    color: $orange-darker;
+    margin-bottom: .35em;
+    border-bottom: 2px solid $orange-darker;
   }
   
   a:active,
   a:hover,
   a:focus {
-    text-decoration: underline;
+    color: $white;
+    text-decoration: none;
+    background-color: $orange-darker;
   }
 }


### PR DESCRIPTION
## Ticket(s)

**Github Issue**

N/A

**Jira Ticket**

- [EWLJ-334: Topic Tag Adjustments](https://issues.ama-assn.org/browse/EWLJ-334)


## Description

Adjust the topic tags which appear on article and podcast detail pages to be repositioned above the references section and to be redesigned to stand out more. 

## To Test

- [ ] Spin up the styleguide
- [ ] Review the tags list molecule at various screen widths, and from a code perspective.
- [ ] Review the tags list molecule that appears on the article detail page
- [ ] Review the tags list molecule that appears on the podcast detail page

## Visual Regressions

This will regress the topic tag icon that currently appears on the Drupal site and should not be merged until that is addressed.

## Relevant Screenshots/GIFs

N/A

## Remaining Tasks

N/A aside from the drupal work noted in the visual regressions section above.

## Additional Notes

The design changes to the tags have been reviewed and approved by the JoE team.
