### PR TITLE
EWLJ-323: Removing CSS rules that limit the image from being displayed full size

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_inline-image.scss
+++ b/styleguide/source/assets/scss/02-molecules/_inline-image.scss
@@ -32,14 +32,6 @@
     margin: 0;
     
     img {
-      position: fixed;
-      top: 50%;
-      left: 50%;
-      max-width: 80%;
-      max-height: 80%;
-      width: auto;
-      transform: translate(-50%, -50%);
-      z-index: 21; 
       opacity: 0;
       animation: fadeIn .5s ease .15s forwards;
        


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

Please do not submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Jira Ticket**

- [EWLJ-323: Need figures and images to magnify when magnified](https://issues.ama-assn.org/browse/EWLJ-323)


## Description

Removed CSS rules that limited the image from being displayed full size.

## To Test
- [ ] Switch your JOE SG2 branch to `EWLJ-323-magnify-full-screen-images`
- [ ] Run gulp serve
- [ ] Enable local SG2 in your D8 project
- [ ] In another terminal run `drush @joe.local cr`
- [ ] Go to http://ama-joe.local/article/why-we-need-music-player-every-patient-room/2019-03
- [ ] Click on the magnifying glass in the top-right corner of an image
- [ ] You should see the image displayed on the whole screen, with `X` icon on the top-right corner of the image
- [ ] Clicking anywhere on the image will close the magnified display and go back to the article page

## Relevant Screenshots/GIFs

Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.
![images-magnified-in-full-screen](https://user-images.githubusercontent.com/22901/55031891-0830d080-4fe6-11e9-96e7-3c70c7f3ee4a.jpg)
