### PR TITLE
EWLJ-364 main menu broken on ipad

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_utility-nav.scss
+++ b/styleguide/source/assets/scss/02-molecules/_utility-nav.scss
@@ -4,6 +4,7 @@
   background-color: $blue-darkest;
   column-count: 1;
   column-gap: 0;
+  border-right: 1px solid $white; 
   background: $navy-lighter;
   
   @include breakpoint($bp-xs) {
@@ -15,16 +16,14 @@
     margin: 0 auto;
     background: $navy-lighter;
     background-color: $navy-lighter;
-
-    .joe__header & {
-      top: -25px;
-      background: none;
-      background-color: transparent;
-    }
   }
   
   @include breakpoint($bp-med) {
     column-count: 1;
+
+    .joe__header & {
+      top: -25px;
+    }
   }
   
   @include breakpoint($bp-large) {

--- a/styleguide/source/assets/scss/03-organisms/_header.scss
+++ b/styleguide/source/assets/scss/03-organisms/_header.scss
@@ -75,6 +75,7 @@
   
   @include breakpoint($bp-med) {
     max-height: none;
+    opacity: 1;
     visibility: visible;
     position: static;
     background: none;

--- a/styleguide/source/assets/scss/03-organisms/_header.scss
+++ b/styleguide/source/assets/scss/03-organisms/_header.scss
@@ -60,16 +60,17 @@
   top: 100%;
   max-height: 0;
   visibility: hidden;
+  transition: max-height .5s ease-in, visibility 0s ease-in .5s, opacity .25s ease-in .25s;
+  opacity: 0;
   background-color: $navy-lighter;
   box-shadow: $shadow;
-  transition: max-height .5s ease-in, visibility 0s ease-in .5s;
-  overflow-y: scroll;
   border-right: 1px solid $white;
   
   &.is-active {
     max-height: 80vh;
     visibility: visible;
-    transition: max-height .5s ease-in, visibility 0s ease-in;
+    transition: max-height .5s ease-in, visibility 0s ease-in, opacity .25s ease-in .25s;
+    opacity: 1;
   }
   
   @include breakpoint($bp-med) {


### PR DESCRIPTION
## Ticket(s)

Please do not submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Jira Ticket**

- [EWLJ-364: Main menu is broken on iPad](https://issues.ama-assn.org/browse/EWLJ-364)


## Description

Main-menu component is generated differently between JoE style guide and its Drupal implementation.
This behavior was affecting Drupal's main menu and wasn't visible in the style guide.

In the current website, when using screen width 400px - 899px, the main menu looks broken.

I disabled the scrolling within the main menu and added the background color to the smaller items at the bottom of the main menu items.

## To Test
- [ ] Switch your JOE SG2 branch to `EWLJ-364-main-menu-ipad`
- [ ] Run gulp serve
- [ ] Enable local SG2 in your D8 project
- [ ] In another terminal run `drush @joe.local cr`
- [ ] Go to any page on the website
- [ ] On full desktop width (anything wider than 900px)
- [ ] The main menu should be visible.
- [ ] While scrolling down, the main menu is hidden
- [ ] Clicking on the hamburger menu should display the menu
- [ ] View the website on a browser that is **less** than 900px wide
- [ ] Now the menu is hidden even at top of the page
- [ ] Clicking on the hamburger menu should display the menu


## Relevant Screenshots/GIFs
Before:
![Screenshot_2019-03-29 Journal of Ethics American Medical Association(1)](https://user-images.githubusercontent.com/22901/55265924-c5266580-5250-11e9-9bab-77473abc9105.png)

After:
![Screenshot_2019-03-29 Journal of Ethics American Medical Association](https://user-images.githubusercontent.com/22901/55265929-ca83b000-5250-11e9-8d54-50c349aca5cc.png)


(no need to change anything on the Drupal site, this is CSS update in styleguide only)