### PR TITLE
EWLJ-213: Displaying flag colors when viewing articles

### DIFF
--- a/styleguide/source/_patterns/01-atoms/flags.json
+++ b/styleguide/source/_patterns/01-atoms/flags.json
@@ -13,7 +13,7 @@
     {
       "type": "Podcast",
       "issue": "Sept. 2017",
-      "class": "joe__flag--red"
+      "class": "joe__flag--orange"
     },
     {
       "type": "Medicine & Society",
@@ -28,7 +28,7 @@
     {
       "type": "Podcast",
       "issue": "Sept. 2017",
-      "class": "joe__flag--red joe__flag--larger"
+      "class": "joe__flag--orange joe__flag--larger"
     }
   ]
 }

--- a/styleguide/source/_patterns/01-atoms/flags.json
+++ b/styleguide/source/_patterns/01-atoms/flags.json
@@ -2,7 +2,8 @@
   "flags": [
     {
       "type": "Medicine & Society",
-      "issue": "Sept. 2017"
+      "issue": "Sept. 2017",
+      "class": "joe__flag--blue"
     },
     {
       "type": "Ethics Case",
@@ -17,7 +18,7 @@
     {
       "type": "Medicine & Society",
       "issue": "Sept. 2017",
-      "class": "joe__flag--larger"
+      "class": "joe__flag--blue joe__flag--larger"
     },
     {
       "type": "Ethics Case",
@@ -31,4 +32,3 @@
     }
   ]
 }
-

--- a/styleguide/source/_patterns/05-pages/article--no-image.json
+++ b/styleguide/source/_patterns/05-pages/article--no-image.json
@@ -370,7 +370,8 @@
       {
         "style": "reverse",
         "flag": {
-          "type": "AMA Code Says"
+          "type": "AMA Code Says",
+          "class": "joe__flag--blue"
         },
         "authors": [
           {
@@ -416,7 +417,8 @@
       { "size": "small",
         "flag": {
           "type": "AMA Code Says",
-          "issue": "Sept. 2017"
+          "issue": "Sept. 2017",
+          "class": "joe__flag--blue"
         },
         "authors": [
           {

--- a/styleguide/source/assets/scss/01-atoms/_flag.scss
+++ b/styleguide/source/assets/scss/01-atoms/_flag.scss
@@ -62,3 +62,15 @@
   background-color: $black-05;
   background: $black-05;
 }
+
+%joe__flag--orange,
+.joe__flag--orange {
+  background-color: $orange-darker;
+  background: $orange-gradient;
+}
+
+%joe__flag--blue,
+.joe__flag--blue {
+  background-color: $navy-lighter;
+  background: $blue-gradient;
+}


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## JIRA Ticket(s)
- [EWLJ-213: Flag colors are not working](https://issues.ama-assn.org/browse/EWLJ-213)


## Description:
Added joe__flag--orange and joe__blag--blue to styleguide

## To Test:

Due to 
- [ ] Switch your JOE SG2 branch to `bug/EWLJ-213-article-flag-color`
- [ ] Run gulp serve
- [ ] Go to http://localhost:3000/?p=atoms-flags
- [ ] You should see the SAME colors we had before (but in the code, it is now using the new explicit flag colors blue, green, orange
Before it was (nothing for default), green and red.

---

## JoE website:
Related PR - https://github.com/AmericanMedicalAssociation/ama-d8/pull/1307