### PR TITLE
EWLJ-373 - Regression: background of links in ribbon header a different blue

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_utility-nav.scss
+++ b/styleguide/source/assets/scss/02-molecules/_utility-nav.scss
@@ -1,11 +1,9 @@
 .joe__utility-nav {
   @extend %clearfix;
   display: block;
-  background-color: $blue-darkest;
   column-count: 1;
   column-gap: 0;
   border-right: 1px solid $white; 
-  background: $navy-lighter;
   
   @include breakpoint($bp-xs) {
     column-count: 2;
@@ -14,8 +12,6 @@
     width: 100%;
     max-width: 1600px;
     margin: 0 auto;
-    background: $navy-lighter;
-    background-color: $navy-lighter;
   }
   
   @include breakpoint($bp-med) {


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## JIRA Ticket(s)
- [EWLJ-373: Regression: background of links in ribbon header a different blue](https://issues.ama-assn.org/browse/EWLJ-373)


## Description:
The additional background color is a regression to the header menu, it needs to be removed in the styleguide.


## To Test:

- [ ] Switch your JOE SG2 branch to `bug/EWLJ-373-header-bg-regression`
- [ ] Run `gulp serve`
- [ ] Confirm the wrong background color is no longer there.
