### PR TITLE
EWLJ-328 - from the archive on home page display

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_topics.scss
+++ b/styleguide/source/assets/scss/03-organisms/_topics.scss
@@ -20,6 +20,12 @@
   list-style: none;
   margin: 2em 0 1em;
   padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+
+  li {
+    width: 100%;
+  }
   
   @include breakpoint($bp-med) {
     li {


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## JIRA Ticket(s)
- [EWLJ-328:from the archive on home page display](https://issues.ama-assn.org/browse/EWLJ-328)

## Description:
From archive section was handling only 2 items, more than that and the display breaks.
Added additional CSS rules -  to support multiple items in a grid, and on mobile screens -  1 vertical column for all items.


## To Test:

Due to 
- [ ] Switch your JOE SG2 branch to `bug/EWLJ-328-homepage-from-archive-grid`
- [ ] Switch your AMA-D8 branch to `develop`
- [ ] Run gulp serve
- [ ] Enable local SG2 in your D8 project
- [ ] In another terminal run `drush @joe.local cr`
- [ ] Edit homepage, and add 6 items in the "from archive" section
- [ ] View the homepage and confirm the items in "from archive" are displayed in a nice grid
- [ ] Test the homepage on mobile screen and confirm all items appear in 1 vertical column
