### PR TITLE
EWLJ-341 - tables are getting a left side gray shadow

### DIFF
--- a/styleguide/source/assets/scss/01-atoms/_table.scss
+++ b/styleguide/source/assets/scss/01-atoms/_table.scss
@@ -19,22 +19,6 @@ table {
     padding: 0px 12px;
   }
 
-  // change these gradients from white to your background colour if it differs
-  // gradient on the first cells to hide the left shadow
-  td:first-child {
-    background-image: linear-gradient(to right, rgba(255,255,255, 1) 50%, rgba(255,255,255, 0) 100%);
-    background-repeat: no-repeat;
-    background-size: 20px 100%;
-  }
-
-  // gradient on the last cells to hide the right shadow
-  td:last-child{
-    background-image: linear-gradient(to left, rgba(255,255,255, 1) 50%, rgba(255,255,255, 0) 100%);
-    background-repeat: no-repeat;
-    background-position: 100% 0;
-    background-size: 20px 100%;
-  }
-
   th {
     @include type($font-serif, .8em, $font-weight-bold, 1.35);
     background: $navy-lighter;

--- a/styleguide/source/assets/scss/01-atoms/_table.scss
+++ b/styleguide/source/assets/scss/01-atoms/_table.scss
@@ -9,11 +9,6 @@ table {
   border-collapse: collapse;
   border-spacing: 0;
   -webkit-overflow-scrolling: touch;
-  background: radial-gradient(ellipse, rgba(0,0,0, .2) 0%, rgba(0,0,0, 0) 75%) -1% center,
-              radial-gradient(ellipse, rgba(0,0,0, .2) 0%, rgba(0,0,0, 0) 75%) 101% center;
-  background-size: 15px 100%, 15px 100%;
-  background-attachment: scroll, scroll;
-  background-repeat: no-repeat;
   
   @include breakpoint($bp-large) {
     white-space: normal;
@@ -58,5 +53,3 @@ table {
     @extend %joe__type--smaller;
   }
 }
-
-


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## JIRA Ticket(s)
- [EWLJ-341:tables are getting a left side gray shadow](https://issues.ama-assn.org/browse/EWLJ-341)

## Description:
Gray shadow was appearing in tables. I removed the gray shadow.


## To Test:

Due to 
- [ ] Switch your JOE SG2 branch to `bug/EWLJ-341-remove-grey-shade-from-table`
- [ ] Switch your AMA-D8 branch to `develop`
- [ ] Run gulp serve
- [ ] Enable local SG2 in your D8 project
- [ ] In another terminal run `drush @joe.local cr`
- [ ] Go to http://ama-joe.local/article/addressing-medical-students-negative-bias-toward-patients-obesity-through-ethics-education/2018-10
- [ ] Scroll down to the table, and confirm that gray shadow on the left side of table is no longer there.
