### PR TITLE
EWLJ-364 - Main menu is broken on iPad

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_utility-nav.scss
+++ b/styleguide/source/assets/scss/02-molecules/_utility-nav.scss
@@ -4,7 +4,8 @@
   column-count: 1;
   column-gap: 0;
   border-right: 1px solid $white; 
-  
+  background-color: $navy-lighter;
+
   @include breakpoint($bp-xs) {
     column-count: 2;
 
@@ -16,6 +17,7 @@
   
   @include breakpoint($bp-med) {
     column-count: 1;
+    background-color: transparent;
 
     .joe__header & {
       top: -25px;
@@ -24,7 +26,7 @@
   
   @include breakpoint($bp-large) {
     width: 100%;
-    
+
     .joe__header & {
       top: -28px;
     }


### PR DESCRIPTION
## Ticket(s)

Please do not submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Jira Ticket**

- [EWLJ-364: Main menu is broken on iPad](https://issues.ama-assn.org/browse/EWLJ-364)


## Description

Main-menu component is generated differently between JoE style guide and its Drupal implementation.
This behavior was affecting Drupal's main menu and wasn't visible in the style guide.

In the current website, when using screen width 400px - 899px, the main menu looks broken.

I disabled the scrolling within the main menu and added the background color to the smaller items at the bottom of the main menu items.

## To Test
- [ ] Switch your JOE SG2 branch to `EWLJ-364-main-menu-ipad`
- [ ] Run gulp serve
- [ ] Enable local SG2 in your D8 project
- [ ] In another terminal run `drush @joe.local cr`
- [ ] Go to any page on the website
- [ ] On full desktop width (anything wider than 900px)
- [ ] The main menu should be visible.
- [ ] While scrolling down, the main menu is hidden
- [ ] Clicking on the hamburger menu should display the menu
- [ ] View the website on a browser that is **less** than 900px wide
- [ ] Now the menu is hidden even at top of the page
- [ ] Clicking on the hamburger menu should display the menu

(no need to change anything on the Drupal site, this is CSS update in styleguide only)