### PR TITLE
EWLJ-329: secondary navigation should sit flush right

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_utility-nav.scss
+++ b/styleguide/source/assets/scss/02-molecules/_utility-nav.scss
@@ -3,7 +3,6 @@
   display: block;
   column-count: 1;
   column-gap: 0;
-  border-right: 1px solid $white; 
   background-color: $navy-lighter;
 
   @include breakpoint($bp-xs) {

--- a/styleguide/source/assets/scss/02-molecules/_utility-nav.scss
+++ b/styleguide/source/assets/scss/02-molecules/_utility-nav.scss
@@ -20,7 +20,8 @@
     background-color: transparent;
 
     .joe__header & {
-      top: -25px;
+      top: -32px;
+      height: 26px;
     }
   }
   
@@ -28,7 +29,8 @@
     width: 100%;
 
     .joe__header & {
-      top: -28px;
+      top: -35px;
+      height: 29px;
     }
   }
   
@@ -52,15 +54,6 @@
   
   @include breakpoint($bp-med) {
     float: right;
-    margin-right: 5.0em;
-  }
-
-  @include breakpoint($bp-large) {
-    margin-right: 5.0em;
-  }
-  
-  @include breakpoint($bp-xl) {
-    margin-right: 0em;
   }
 }
 

--- a/styleguide/source/assets/scss/03-organisms/_header.scss
+++ b/styleguide/source/assets/scss/03-organisms/_header.scss
@@ -77,7 +77,7 @@
     max-height: none;
     opacity: 1;
     visibility: visible;
-    position: static;
+    position: relative;
     background: none;
     background-color: transparent;
     box-shadow: none;


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

Please do not submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Jira Ticket**

- [EWLJ-329: ](https://issues.ama-assn.org/browse/EWLJ-329)


## Description

Changed the structure of `joe__nav-drawer`

## To Test
- [ ] Switch your JOE SG2 branch to `EWLJ-329-secondary-nav-sit-flush-right`
- [ ] Run gulp serve
- [ ] Enable local SG2 in your D8 project
- [ ] In another terminal run `drush @joe.local cr`
- [ ] Go to any page of http://ama-joe.local/
- [ ] Modify the screen width of your browser and confirm 2nd nav always stay flush right
