### PR TITLE
EWLJ-400: Read More text needs more space under it

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_issue-teaser.scss
+++ b/styleguide/source/assets/scss/02-molecules/_issue-teaser.scss
@@ -50,5 +50,5 @@
 .joe__issue-teaser__link {
   @extend %joe__link--bold;
   display: inline-block;
-  margin-top: 1.5em;
+  margin: 1.5em 0 3em 0;
 }


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## JIRA Ticket(s)
- [EWLJ-400: Read More text needs more space under it](https://issues.ama-assn.org/browse/EWLJ-400)


## Description:
Affecting narrow screens (under 900px) -
On the homepage, added an extra space under read-more of the main featured issue.

## To Test:

- [ ] Switch your JOE SG2 branch to `feature/EWLJ-400-space-under-read-more-homepage`
- [ ] Run gulp serve
- [ ] Enable local SG2 in your D8 project
- [ ] In another terminal run `drush @joe.local cr`
- [ ] Make sure your browser width is smaller than 900px
- [ ] Go to http://ama-joe.local/
- [ ] See that there's an extra space between the first featured issue's "Read more" and the rest of featured content.

## Screenshot:
![image](https://user-images.githubusercontent.com/22901/56768369-2a03ab80-677c-11e9-83df-697630c67579.png)
