### PR TITLE
EWLJ-411: Read more feature request for spacing

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_references.scss
+++ b/styleguide/source/assets/scss/02-molecules/_references.scss
@@ -1,5 +1,7 @@
 .joe__references {
-  margin-bottom: 1em;
+  margin: 2.5em 0 1em;
+  padding-top: 2em;
+  border-top: 1px solid $black-20;
 }
 
 .joe__references__list,

--- a/styleguide/source/assets/scss/02-molecules/_tags-list.scss
+++ b/styleguide/source/assets/scss/02-molecules/_tags-list.scss
@@ -7,15 +7,8 @@
 
 .joe__tags {
   position: relative;
-  margin: 1em 0 3em;
-  padding: 2em 0 3em;
   clear: both;
-
-  border-bottom: 1px solid $black-20;
-  
-  @include breakpoint($bp-med) {
-    padding: 2em 0;
-  }
+  padding-top: 1em;
 }
 
 .joe__tags-list {

--- a/styleguide/source/assets/scss/03-organisms/_article-footer.scss
+++ b/styleguide/source/assets/scss/03-organisms/_article-footer.scss
@@ -2,7 +2,7 @@
   @extend %joe__type--small;
   background-color: $black-10;
   padding: $gutter-mobile;
-  margin-top: 3em;
+  margin: 3em 0;
   
   .joe__title-label {
     @include type($font-serif, .875em, $font-weight-bold, 1.25);

--- a/styleguide/source/assets/scss/03-organisms/_article-footer.scss
+++ b/styleguide/source/assets/scss/03-organisms/_article-footer.scss
@@ -2,7 +2,7 @@
   @extend %joe__type--small;
   background-color: $black-10;
   padding: $gutter-mobile;
-  margin: 0;
+  margin-top: 3em;
   
   .joe__title-label {
     @include type($font-serif, .875em, $font-weight-bold, 1.25);

--- a/styleguide/source/assets/scss/05-pages/_article.scss
+++ b/styleguide/source/assets/scss/05-pages/_article.scss
@@ -34,7 +34,3 @@
   @include gutter($margin-bottom-full...);
   background-color: $white;
 }
-
-.joe__page-content--article {
-  padding-top: 5px;
-}


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## JIRA Ticket(s)
- [EWLJ-411: Read more feature request for spacing](https://issues.ama-assn.org/browse/EWLJ-411)
- [EWLJ-347: Add an extra line at the end of article full text](https://issues.ama-assn.org/browse/EWLJ-347)
- [EWLJ-370: update topic tags on JOE site to match styleguide work](https://issues.ama-assn.org/browse/EWLJ-370)
- [EWLJ-405: Spacing above/below citations](https://issues.ama-assn.org/browse/EWLJ-405)

## Description:
There were multiple instances of inconsistent spacing between the various sections of article pages.
EWLJ-370 introduced a new order of these sections.
The solution was to create consistent space above & below each section, so whether one or some sections do not exist in an article - it wouldn't change the consistent spacing.


## To Test:

- [ ] Switch your AMA-D8 branch to `feature/EWLJ-411-article-tags-and-references-spacing`
- [ ] Switch your JOE SG2 branch to `feature/EWLJ-411-article-tags-and-references-spacing`
- [ ] Run gulp serve
- [ ] switch your D8 branch to `feature/EWLJ-411-spacing`
- [ ] Enable local SG2 in your D8 project
- [ ] In another terminal run `drush @joe.local cr`
- [ ] Confirm that there's consistent spacing above/below the article text, Read More (tags), References, and Citation (grey box) in the following pages:

- [ ] [http://ama-joe.local/article/should-psychiatrist-prescribe-nanodrug-help-parents-monitor-teens-adherence/2019-04](http://ama-joe.local/article/should-psychiatrist-prescribe-nanodrug-help-parents-monitor-teens-adherence/2019-04)
- [ ] [http://ama-joe.local/article/journeys/2019-04](http://ama-joe.local/article/journeys/2019-04)
- [ ] [http://ama-joe.local/article/innovating-nanoethics/2019-04](http://ama-joe.local/article/innovating-nanoethics/2019-04)


_Related PR in ama-d8:_
https://github.com/AmericanMedicalAssociation/ama-d8/pull/1380


## Screenshots:
![image](https://user-images.githubusercontent.com/22901/57111559-9fd2be80-6d0a-11e9-8efd-64972eee94f4.png)
