### PR TITLE
EWLJ-404: Change Podcast player and height

### DIFF
--- a/styleguide/source/assets/scss/01-atoms/_audio-player.scss
+++ b/styleguide/source/assets/scss/01-atoms/_audio-player.scss
@@ -6,7 +6,7 @@
   clear: both;
   
   iframe {
-    height: 50px;
+    height: 90px;
     width: 100%; 
     padding-top: 5px;
     border: none;


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

**Jira Ticket**

- [EWLJ-404: Change Podcast player and height](https://issues.ama-assn.org/browse/EWLJ-404)


## Description

- Adds height to podcast player, so play time, controls and libsyn logo appears. 

## To Test

- [ ] Enable local styleguide for JoE
- [ ] Navigate to http://ama-joe.local/podcast/when-and-how-should-ecmo-be-initiated-and-removed (or other podcast pages with players). 
   - Currently on prod: https://journalofethics.ama-assn.org/podcast/when-and-how-should-ecmo-be-initiated-and-removed


- [ ] Observe that the player looks like the below: 

![Screen Shot 2019-05-28 at 12 40 47 PM](https://user-images.githubusercontent.com/541745/58495724-2d58d100-8146-11e9-8f4b-4caf33d4668c.png)
   - I tried to remove the border to make it a little less blocky (around the play time, controls, logo), but not able to easily do it as it being styled from Libsyn's CSS.

## Visual Regressions

N/A

## Relevant Screenshots/GIFs

N/A

## Remaining Tasks


## Additional Notes

N/A
