### PR TITLE
EWLJ-481 Superscripts tooltip behavior is incorrect

### DIFF
--- a/styleguide/source/assets/js/resource-tooltips.js
+++ b/styleguide/source/assets/js/resource-tooltips.js
@@ -17,7 +17,7 @@
          if (supText.indexOf(',') > -1) {
            $sup.replaceWith($sup.text().split(',').map(function(el, i) {
              // If the sup number is the last one it should not have a comma after it
-             return $sup.length !== i - 1  ? '<sup>' + el + ', </sup>' : '<sup>' + el + '</sup>'
+             return $sup.text().split(',').length - 1 !== i ? '<sup>' + el + ', </sup>' : '<sup>' + el + '</sup>'
            }));
          }
        });
@@ -31,9 +31,15 @@
           // Prevent the hover function from cloning the reference more than once
           if(!$(this).find('.ama__tooltip').length){
             // Append a div with the reference to the <sup>
-            $(this).append('<div class="ama__tooltip">' + $reference.html() + '</div>');
-            // Show the reference tooltip
-            $(this).children('.ama__tooltip').fadeIn()
+            if($reference.html() === undefined) {
+              $(this).append('<div class="ama__tooltip">Reference not found.</div>');
+              // Show the reference tooltip
+              $(this).children('.ama__tooltip').fadeIn()
+            } else {
+              $(this).append('<div class="ama__tooltip">' + $reference.html() + '</div>');
+              // Show the reference tooltip
+              $(this).children('.ama__tooltip').fadeIn()
+            }
           } else {
             $(this).find('.ama__tooltip').fadeIn();
           }


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

Please do not submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Jira Ticket**

- [EWLJ-481 Superscripts tooltip behavior is incorrect](https://issues.ama-assn.org/browse/EWL-481)


## Description

Superscript array is not showing commas in the correct spots.

## To Test

- pull this branch `bugfix/EWLJ-481-Superscripts-tooltip-behavior-is-incorrect`
- run `scripts/refresh-local -s -a joe`
- visit http://ama-joe.local/article/evolving-medicaid-coverage-policy-and-rebates/2019-08
- if that returns a 404
- then manual intervention is required. Go to the Acquia site and download the latest Joe DB  and import that one
- observe the superscripts with more than 3 numbers have commas in the right place and the last number doesn't have a comma

## Visual Regressions

Does your work introduce any visual regressions to existing work in the Style Guide, or in a Drupal 8 environment? Please either call these out here or address them before marking your PR as `ready for review`.


## Relevant Screenshots/GIFs
<img width="1133" alt="superscript" src="https://user-images.githubusercontent.com/2271747/61078353-0e588a80-a3e6-11e9-94ce-ff9c2ade8500.png">

Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks

Remaining tasks?


## Additional Notes

I also added a condition in which a number cannot be found returns text that says `Resource cannot be found`