### PR TITLE
EWLJ-481 Superscripts tooltip behavior not working correctly in all scenarios

### DIFF
--- a/styleguide/source/assets/js/resource-tooltips.js
+++ b/styleguide/source/assets/js/resource-tooltips.js
@@ -11,7 +11,7 @@
    Drupal.behaviors.resourceToolips = {
      attach: function () {
        // Separates the sup tags that have multiple numbers into individual sup tags
-       $('sup').each(function(){
+       $('article sup').each(function(){
          var $sup = $(this);
          var supText = $sup.text().trim();
          if (supText.indexOf(',') > -1) {

--- a/styleguide/source/assets/js/resource-tooltips.js
+++ b/styleguide/source/assets/js/resource-tooltips.js
@@ -11,7 +11,7 @@
    Drupal.behaviors.resourceToolips = {
      attach: function () {
        // Separates the sup tags that have multiple numbers into individual sup tags
-       $('p sup').each(function(){
+       $('sup').each(function(){
          var $sup = $(this);
          var supText = $sup.text().trim();
          if (supText.indexOf(',') > -1) {


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

Please do not submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Jira Ticket**

- [EWLJ-481 Superscripts tooltip behavior is incorrect](https://issues.ama-assn.org/browse/EWL-481)

This ticket does not correctly showcase the bug. It was reopened due to client observing that the tooltips did not work correctly in all instances


## Description

Superscript tooltips don't work in scenarios when they are enclosed in anything other than <p> tags. 

## To Test

- pull this branch `bugfix/EWLJ-481-Superscripts-tooltip-behavior-is-incorrect`
- run `scripts/refresh-local -s -a joe`
- visit http://ama-joe.local/article/response-emerging-roles-virtual-patients-age-ai/2019-10
- if that returns a 404
- then manual intervention is required. Go to the Acquia site and download the latest Joe DB  and import that one
- hover over the tooltips for 16, 17, 32, 33, 34, 35
- observe they show the correct citations

## Visual Regressions

Does your work introduce any visual regressions to existing work in the Style Guide, or in a Drupal 8 environment? Please either call these out here or address them before marking your PR as `ready for review`.


## Relevant Screenshots/GIFs
<img width="1194" alt="Screen Shot 2019-09-23 at 3 23 08 PM" src="https://user-images.githubusercontent.com/2271747/65459716-14231100-de16-11e9-9ff2-f4b93fdfcda7.png">


Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks

Remaining tasks?


## Additional Notes

I also added a condition in which a number cannot be found returns text that says `Resource cannot be found`