### PR TITLE
EWLJ-407: Add no wrap

### DIFF
--- a/styleguide/source/assets/scss/01-atoms/_tooltip.scss
+++ b/styleguide/source/assets/scss/01-atoms/_tooltip.scss
@@ -11,5 +11,4 @@
   z-index: 10;
   left: 0;
   top: 0;
-  word-break: break-all;
 }

--- a/styleguide/source/assets/scss/02-molecules/_references.scss
+++ b/styleguide/source/assets/scss/02-molecules/_references.scss
@@ -23,6 +23,7 @@
 
 .joe__references__item-links{
   a {
-    margin-right: 15px;
+    white-space: nowrap;
+    margin-right: 10px;
   }
 }

--- a/styleguide/source/assets/scss/02-molecules/_references.scss
+++ b/styleguide/source/assets/scss/02-molecules/_references.scss
@@ -23,7 +23,6 @@
 
 .joe__references__item-links{
   a {
-    white-space: nowrap;
     margin-right: 10px;
   }
 }


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

Please do not submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Jira Ticket**

- [EWLJ-407: Reference box cut off](https://issues.ama-assn.org/browse/EWLJ-407)


## Description
Update `Google Scholar link` and other links so we don't "break" words.


## To Test

- [ ] Build `Styleguide`
- [ ] Visit `http://localhost:3000/?p=pages-article`
- [ ] Verify that 'Google Scholar' the word, does not break to the next line.

Bad: 
![Screen Shot 2019-10-18 at 9 27 11 AM](https://user-images.githubusercontent.com/231467/67098132-968ac080-f189-11e9-9b4c-1a6764be43db.png)
