### PR TITLE
EWLJ-528 reworked lightbox function

### DIFF
--- a/styleguide/source/assets/js/lightbox.js
+++ b/styleguide/source/assets/js/lightbox.js
@@ -8,35 +8,41 @@
  * - http://www.adequatelygood.com/2010/3/JavaScript-Module-Pattern-In-Depth
  */
 (function ($, Drupal) {
-  'use strict';
+  'use strict'
 
   Drupal.behaviors.lightbox = {
     attach: function (context, settings) {
       // Opens and closes lightbox.
-      $('.joe__inline-image__zoom').click(function(e) {
-        e.preventDefault();
-        e.stopPropagation();
+      $('.joe__inline-image__zoom').click(function (e) {
+        e.preventDefault()
+        e.stopPropagation()
         // Unfocus on the dropdown
-        $(this).blur();
+        $(this).blur()
+        var $width = $('.layout-container').width()
         // add a class to the sibling dropdown
-        var $figure = $(this).closest('.joe__inline-image');
-        $figure.toggleClass('is-zoomed');
-        $figure.css('max-width', $('.layout-container').width());
-      });
+        var $figure = $(this).closest('.joe__inline-image')
+        $figure.toggleClass('is-zoomed')
+
+        if ($figure.hasClass('is-zoomed')) {
+          $figure.css('width', $width)
+        } else {
+          $figure.removeAttr('style')
+        }
+      })
 
       // Close the modal when esc is pressed.
-      $(document).on('keydown', function(e) {
+      $(document).on('keydown', function (e) {
         if (e.keyCode === 27) {
-          $(".joe__inline-image").removeClass('is-zoomed');
+          $('.joe__inline-image').removeClass('is-zoomed').removeAttr('style')
         }
-      });
+      })
 
-      $(document).on('click', function(e) {
-         var target = $(e.target);
-         if (target.is(':not(img)')) {
-           $(".joe__inline-image").removeClass('is-zoomed');
-         }
-      });
+      $(document).on('click', function (e) {
+        var target = $(e.target)
+        if (target.is(':not(img)')) {
+          $('.joe__inline-image').removeClass('is-zoomed').removeAttr('style')
+        }
+      })
     }
-  };
-})(jQuery, Drupal);
+  }
+})(jQuery, Drupal)

--- a/styleguide/source/assets/js/lightbox.js
+++ b/styleguide/source/assets/js/lightbox.js
@@ -25,8 +25,10 @@
 
         if ($figure.hasClass('is-zoomed')) {
           $figure.css('width', $width)
+          $('.contextual-region').css('position', 'static')
         } else {
           $figure.removeAttr('style')
+          $('.contextual-region').css('position', 'relative')
         }
       })
 
@@ -34,6 +36,7 @@
       $(document).on('keydown', function (e) {
         if (e.keyCode === 27) {
           $('.joe__inline-image').removeClass('is-zoomed').removeAttr('style')
+          $('.contextual-region').css('position', 'relative')
         }
       })
 
@@ -41,6 +44,7 @@
         var target = $(e.target)
         if (target.is(':not(img)')) {
           $('.joe__inline-image').removeClass('is-zoomed').removeAttr('style')
+          $('.contextual-region').css('position', 'relative')
         }
       })
     }


### PR DESCRIPTION
## Ticket(s)

- [Modal expansion is inconsistent](https://issues.ama-assn.org/browse/EWLJ-528)

**Github Issue**

N/A

**Jira Ticket**

- [Modal expansion is inconsistent](https://issues.ama-assn.org/browse/EWLJ-528)


## Description

Images were only expanding to their natural width. Updated function to force 100% width on expand, and clean up properly on return.


## To Test

- [ ] set up d8 repo for local styleguide development
- [ ] pull this branch and run `gulp serve`
- [ ] visit this page and expand the image http://ama-joe.local/article/anatomy-medical-student/2019-09
- [ ] confirm that the image fills the page width and returns to normal when modal is closed.

## Visual Regressions

N/A


## Relevant Screenshots/GIFs

N/A


## Remaining Tasks

Chad wants this out by Thurs, so if it passes, lets cut a JOE sytleguide release


## Additional Notes

N/A
