### PR TITLE
EWLJ-550: removed some questionable formatting from the tool drawer styles.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_article-tools.scss
+++ b/styleguide/source/assets/scss/02-molecules/_article-tools.scss
@@ -7,42 +7,14 @@
   display: flex;
   display: -webkit-flex;
   justify-content: flex-end;
-  
+
   .joe__button--tool {
     float: right;
     margin: 0 0 0 4px;
     position: relative;
-    
+
     @include breakpoint($bp-med) {
       margin: 0 0 0 8px;
-    }
-  }
-  
-  .joe__tool-drawer {
-    
-    .joe__button--tool {
-      position: relative;
-      
-      right: 119px;
-      @include breakpoint($bp-med) {
-        right: 134px;
-      }
-      
-      @include breakpoint($bp-large) {
-        right: 142px;
-      }
-    }
-  }
-  
-  &.joe__article-tools--no-pdf .joe__tool-drawer .joe__button--tool {
-    right: 52px;
-    
-    @include breakpoint($bp-med) {
-      right: 54px;
-    }
-    
-    @include breakpoint($bp-large) {
-      right: 57px;
     }
   }
 }

--- a/styleguide/source/assets/scss/02-molecules/_tool-drawer.scss
+++ b/styleguide/source/assets/scss/02-molecules/_tool-drawer.scss
@@ -1,11 +1,3 @@
-.joe__tool-drawer {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 0;
-}
-
 .joe__tool-drawer__content {
   @extend %joe__type--smallest;
   text-align: left;


### PR DESCRIPTION
## Ticket(s)

Please do not submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**
N/A

**Jira Ticket**

- [EWLJ-550: Incorrect tool drawer formatting when pdf absent](https://issues.ama-assn.org/browse/EWLJ-550)


## Description

Removed strange formatting from the tools drawer of the Joe Article CT


## To Test

- [ ] Set up D8 for Joe local styleguide development
- [ ] pull branch and run ` gulp serve`
- [ ] Make an article without a pdf. Save and verify that the tabs along the top of the page display correctly.
- [ ] edit the page and add a pdf. Save and verify that the tabs display correctly.

## Visual Regressions

N/A


## Relevant Screenshots/GIFs

![2020-06-04_ Article PDF](https://user-images.githubusercontent.com/10862145/83797225-ec07d500-a667-11ea-9848-120896d7de10.png)


## Remaining Tasks

N/A


## Additional Notes

N/A
