### PR TITLE
EWL-9040: set image height property.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_inline-image.scss
+++ b/styleguide/source/assets/scss/02-molecules/_inline-image.scss
@@ -6,7 +6,7 @@
 .joe__inline-caption {
   @extend %joe__type--smaller;
   margin-top: .5em;
-  
+
   .is-zoomed & {
     display: none;
   }
@@ -18,8 +18,9 @@
 
   img {
     width: 100%;
+    height: 100%;
   }
-  
+
   &.is-zoomed {
     position: absolute;
     left: 0;
@@ -29,14 +30,14 @@
     overflow: auto;
     transition: background-color .15s ease;
     background-color: rgba($black, .95);
-    
+
     img {
       opacity: 0;
       animation: fadeIn .5s ease .15s forwards;
-       
+
       .no-cssanimations & {
         opacity: 1;
-      }    
+      }
     }
 
     .joe__inline-image__zoom {
@@ -67,7 +68,7 @@
     width: 50%;
     float: left;
     margin: .5em 1em .5em 0;
-    
+
     &.is-zoomed {
       float: none;
       margin: 0;
@@ -81,7 +82,7 @@
     width: 50%;
     float: right;
     margin: .5em 0 .5em 1em;
-    
+
     &.is-zoomed {
       float: none;
       margin: 0;
@@ -94,7 +95,7 @@
   float: left;
   top: 100%;
   margin: .5em 1em .5em 0;
-  
+
   &.is-zoomed {
     float: none;
     margin: 0;
@@ -118,7 +119,7 @@
   border-radius: 0;
   padding: 6px;
   cursor: pointer;
-  
+
   &:after {
     content: 'Zoom in on this Image';
     background-image: url('../images/zoom-blue.png');
@@ -130,13 +131,13 @@
     font-size: 0;
     overflow: hidden;
   }
-  
+
   &:active,
   &:hover,
   &:focus {
     background-color: $navy-lighter;
     background: $blue-gradient;
-  
+
     &:after {
       background-image: url('../images/zoom-white.png');
     }


### PR DESCRIPTION
**Jira Ticket**

- [EWL-9040: D9 Compliance: Testing JOE site - Images getting stretched issue](https://issues.ama-assn.org/browse/EWL-9040)


## Description

Set image height property to stop stretched images


## To Test

- [ ]  pull and serve. 
- [ ] Set up D8 for styleguide development `lando link-styleguides -a joe && lando drush @joe.local cr`
- [ ] Go to http://journalofethics.lndo.site/article/animated-portrait-inaccessibly-high-cost-care/2021-08 and verify that the image in the article body is not stretched or distorted.

## Visual Regressions

N/A


## Relevant Screenshots/GIFs

N/A


## Remaining Tasks

N/A


## Additional Notes
N/A
