### PR TITLE
(Palantir) ACI-187: JoE: Reference Journal Title Field

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_references.scss
+++ b/styleguide/source/assets/scss/02-molecules/_references.scss
@@ -10,7 +10,7 @@
   @extend %joe__type--small;
   padding-left: 1em;
   word-wrap: break-word;
-  
+
   p {
     display: inline;
   }
@@ -21,7 +21,11 @@
   margin-bottom: 1em;
 }
 
-.joe__references__item-links{
+.joe__references__journal-title {
+  font-style: italic;
+}
+
+.joe__references__item-links {
   a {
     margin-right: 10px;
   }

--- a/styleguide/source/assets/scss/02-molecules/_references.scss
+++ b/styleguide/source/assets/scss/02-molecules/_references.scss
@@ -21,12 +21,12 @@
   margin-bottom: 1em;
 }
 
-.joe__references__journal-title {
-  font-style: italic;
-}
-
 .joe__references__item-links {
   a {
     margin-right: 10px;
   }
+}
+
+.joe__references__journal-title {
+  font-style: italic;
 }


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Github Issue**

- [Issue XXX: Issue Title](https://github.com/AmericanMedicalAssociation/joe-style-guide/issues/XXX)

**Jira Ticket**

- [ACI-187: JoE: Reference Journal Title field](https://palantir.atlassian.net/browse/ACI-187)


## Description

Modified the **_references.scss** file for reference journal title field.


## To Test

- Checkout the aci-187-joe-reference-journal-title-field-style branch on the  joe-style-guide repository

- Verified that  **.joe__references__journal-title {font-style: italic;}**  exists under
styleguide/source/assets/scss/02-molecules/_references.scss

- Navigate to the JOE site's Article node to inspect the References/ reference journal title   to make sure it's styling properly.


## Relevant Screenshots/GIFs

![Screen Shot 2022-07-26 at 8 41 17 AM](https://user-images.githubusercontent.com/54925022/181060475-a73d926c-87b3-4e99-bc94-01cb2a31c2b7.png)


## Remaining Tasks

N/A


## Additional Notes

This ticket is related to the ama-d8 repository ticket **ACI-187 : Joe Reference Journal Title** . Please check out the PR at https://github.com/AmericanMedicalAssociation/ama-d8/pull/3489
