### PR TITLE
Add right alignment to rtl

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_article-teaser.scss
+++ b/styleguide/source/assets/scss/03-organisms/_article-teaser.scss
@@ -124,6 +124,10 @@
     text-decoration: underline;
     border-bottom: 0;
   }
+
+  p[dir="RTL"] {
+    text-align: right; // For right to left language titles.
+  }
 }
 
 .joe__article-teaser__meta {


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

**Jira Ticket**

- https://palantir.atlassian.net/browse/ACI-188


## Description

- Adds right text alignment for RTL teaser titles.


## To Test

- Compile the styleguide and spin up the local environment for Journal of Ethics. Visit /cases, and scroll down to the teaser that has Arabic title.
- Verify that the Arabic title is right aligned.
- @joshuathorne @caharder Palantir team members are not able to compile the JoE styleguide - so I was not able to test this. Screenshot below for what it should look like.
<img width="1480" alt="Screen Shot 2022-08-03 at 11 07 10 AM" src="https://user-images.githubusercontent.com/10488517/182657553-d0dd6d3c-f507-46b1-aa61-f0896f4c189a.png">


## Visual Regressions

Does your work introduce any visual regressions to existing work in the Style Guide, or in a Drupal 8 environment? Please either call these out here or address them before marking your PR as `ready for review`.


## Relevant Screenshots/GIFs

Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.


## Remaining Tasks

Remaining tasks?


## Additional Notes

Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?
