### PR TITLE
[EWLJ-689] OSX/iOS mobile hamburger menu bugfixes

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_utility-nav.scss
+++ b/styleguide/source/assets/scss/02-molecules/_utility-nav.scss
@@ -5,6 +5,9 @@
   column-count: 1;
   column-gap: 0;
   background-color: $navy-lighter;
+  border-left: 1px solid white;
+  border-right: 1px solid white;
+  column-rule: 1px solid white;
 
   @include breakpoint($bp-xs) {
     column-count: 2;
@@ -43,6 +46,7 @@
   list-style: none;
   margin: 0;
   padding: 0;
+  line-height: inherit;
 
   @include breakpoint($bp-med) {
     float: left;
@@ -124,11 +128,11 @@
 
   a:link,
   a:visited {
-    display: block;
+    display: inline-block;
+    width: 100%;
     padding: .75em .75em;
     color: $white;
     border: 0;
-    border-left: 1px solid $white;
   }
 
   @include breakpoint($bp-med) {


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

Please do not submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**

- [Issue XXX: Issue Title](https://github.com/AmericanMedicalAssociation/joe-style-guide/issues/XXX)

**Jira Ticket**

- [EWLJ-689: Hamburger Menu bugfix](https://issues.ama-assn.org/browse/EWLJ-689)


## Description

iOS / OSX didn't respect the padding/line-height of the anchor tag menu items, which lead to some odd positioning. Updated to use inline-block, and reseting the line-height for the elements seemed to correct the padding challenges.

Updated the border structure for mobile, to use the container instead of the individual elements where possible.


## To Test

- Merge code, compile SASS
- with Safari, enable developer mode, then enable responsive design mode
- Select 'iPad', and scroll downward on the homepage to trigger the homepage hamburger menu icon
- Click the menu and observe that there is no uncomfortable overlap of elements, and they align perfectly in two columns

## Additional Notes

Anything more to add? Good things to call out here are:
- An example of the wrong display exists in the JIRA ticket
- This was also tested in Chrome without any regression
