### PR TITLE
[EWLJ-654] Created RTL stylesheet 

### DIFF
--- a/styleguide/source/assets/scss/00-base/_rtl.scss
+++ b/styleguide/source/assets/scss/00-base/_rtl.scss
@@ -1,0 +1,23 @@
+article[dir='rtl'] {
+  text-align: left;
+  direction: ltr;
+
+  h2.joe__article-header__title {
+    text-align: right;
+    direction: rtl;
+  }
+
+  .joe__page-content.joe__article {
+    text-align: right;
+    direction: rtl;
+  }
+
+  .joe__page-content--article {
+    text-align: left;
+  }
+
+  footer.joe__article-footer p {
+    text-align: right;
+  }
+}
+

--- a/styleguide/source/assets/scss/02-molecules/_utility-nav.scss
+++ b/styleguide/source/assets/scss/02-molecules/_utility-nav.scss
@@ -20,6 +20,9 @@
   @include breakpoint($bp-med) {
     column-count: 1;
     background-color: transparent;
+    border-left: none;
+    border-right: none;
+    column-rule: none;
 
     .joe__header & {
       top: -32px;


### PR DESCRIPTION
Converting RTL article pages, to retain the LTR layout, positioning translated content only

## Ticket(s)

Please do not submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Jira Ticket**

- [EWLJ-654: The Arabic language reads from right to left.](https://issues.ama-assn.org/browse/EWLJ-654)

## Description

Target RTL content on articles, setting the layout to retain LTR, and only adjust targeted pieces of translated content.

## To Test

- [ ] Merge Code, Clear caches
- [ ] Review any article page with "https://.../ar/..." in the URL (this indicates a genuine translated Arabic RTL article)
- [ ] Observe that the layout matches the english version
- [ ] Observe that only the content changes to RTL

