### PR TITLE
[EWLJ-654] Removes the footer box-shadow 

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_footer.scss
+++ b/styleguide/source/assets/scss/03-organisms/_footer.scss
@@ -4,10 +4,14 @@
   background-color: $white;
   box-shadow: $shadow;
   text-align: center;
-  
+
   @include breakpoint($bp-small) {
     text-align: left;
   }
+}
+
+main + .joe__footer {
+  box-shadow: inherit;
 }
 
 .joe__footer-brand {
@@ -15,17 +19,17 @@
   display: block;
   margin: 1em auto 0;
   max-width: 150px;
-  
+
   img {
     max-width: 100%;
     width: 100%;
   }
-  
+
   &:link,
   &:visited {
     border-bottom: 0;
   }
-  
+
   @include breakpoint($bp-small) {
     float: right;
     display: inline-block;
@@ -39,11 +43,11 @@
 .joe__footer__block {
   display: inline-block;
   margin-right: 1.5em;
-  
+
   p, a {
     @extend %joe__type--smaller;
   }
-  
+
   @include breakpoint($bp-small) {
     margin-left: 1.5em;
     margin-right: 0;


### PR DESCRIPTION
If the main container is tucked directly against the footer, as is the case for translated articles without a related articles block.

<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

Please do not submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**

N/A

**Jira Ticket**

- [EWLJ-654: The Arabic language LTR](https://issues.ama-assn.org/browse/EWLJ-654)


## Description

Corrected a visual bug, were the footer has a dropshadow, but without any block or container between it and the main section.


## To Test

- [ ] Merge code, recompile theme
- [ ] Go to an [Arabic Translated article](https://journalofethics.ama-assn.org/article/hl-yjb-tsjyl-alatfal-fy-alabhath-alsryryt-fy-mnatq-alsra/2022-06)
- [ ] Observe the footer doesn't show a dropshadow
- [ ] To compare, see the [JOE Home](https://journalofethics.ama-assn.org/home) or the source [english article](https://journalofethics.ama-assn.org/article/should-children-be-enrolled-clinical-research-conflict-zones/2022-06) for the above Arabic article

## Visual Regressions

N/A


## Relevant Screenshots/GIFs

See Screenshots on the JIRA ticket


## Remaining Tasks
N/A


## Additional Notes
N/A
