### PR TITLE
JOE-20: Prototype base styles

### DIFF
--- a/styleguide/source/_meta/_00-head.twig
+++ b/styleguide/source/_meta/_00-head.twig
@@ -1,32 +1,39 @@
 <!DOCTYPE html>
-<html class="{{ htmlClass }}">
-<head>
-  <title>{{ title }}</title>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width" />
-  
-  {# AMA Typekit Account #}
-  <link rel="stylesheet" href="https://use.typekit.net/arm2urd.css">
-  
-  <!-- Grunticon loader -->
-  <script src="../../assets/icons/grunticon.loader.js"></script>
-  <script>grunticon(["../../assets/icons/icons.data.svg.css", "../../assets/icons/icons.data.png.css", "../../assets/icons/icons.fallback.css"], grunticon.svgLoadedCallback );</script>
-  <noscript><link href="icons.fallback.css" rel="stylesheet"></noscript>
+<html class="{{ htmlClass }}" {% if theme_mode %} data-theme="{{ theme_mode }}" {% endif %}>
+  <head>
+    <title>{{ title }}</title>
+    <meta charset="UTF-8">
+    <meta
+    name="viewport" content="width=device-width"/>
 
-  <link rel="stylesheet" href="../../assets/css/styles.css?{{ cacheBuster }}" media="all" />
-  <link rel="stylesheet" href="../../assets/css/pattern-scaffolding.css?{{ cacheBuster }}" media="all" />
+    {# AMA Typekit Account #}
+    <link
+    rel="stylesheet" href="https://use.typekit.net/arm2urd.css">
 
-  <link rel="apple-touch-icon" sizes="180x180" href="../../assets/favicons/apple-touch-icon.png" />
-  <link rel="icon" type="image/png" href="../../assets/favicons/favicon-32x32.png" sizes="32x32" />
-  <link rel="icon" type="image/png" href="../../assets/favicons/favicon-16x16.png" sizes="16x16" />
-  <link rel="manifest" href="../../assets/favicons/manifest.json" />
-  <link rel="mask-icon" href="../../assets/favicons/safari-pinned-tab.svg" color="#46166b" />
-  <meta name="theme-color" content="#ffffff" />
+    <!-- Grunticon loader -->
+    <script src="../../assets/icons/grunticon.loader.js"></script>
+    <script>
+      grunticon([
+        "../../assets/icons/icons.data.svg.css", "../../assets/icons/icons.data.png.css", "../../assets/icons/icons.fallback.css"
+      ], grunticon.svgLoadedCallback);
+    </script>
+    <noscript><link href="icons.fallback.css" rel="stylesheet"></noscript>
 
-  <!-- Begin Pattern Lab (Required for Pattern Lab to run properly) -->
-  {{ patternLabHead | raw }}
-  <!-- End Pattern Lab -->
+    <link rel="stylesheet" href="../../assets/css/styles.css?{{ cacheBuster }}" media="all"/>
+    <link rel="stylesheet" href="../../assets/css/pattern-scaffolding.css?{{ cacheBuster }}" media="all"/>
 
-</head>
-<body class="{{ bodyClass }}">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../assets/favicons/apple-touch-icon.png"/>
+    <link rel="icon" type="image/png" href="../../assets/favicons/favicon-32x32.png" sizes="32x32"/>
+    <link rel="icon" type="image/png" href="../../assets/favicons/favicon-16x16.png" sizes="16x16"/>
+    <link rel="manifest" href="../../assets/favicons/manifest.json"/>
+    <link rel="mask-icon" href="../../assets/favicons/safari-pinned-tab.svg" color="#46166b"/>
+    <meta
+    name="theme-color" content="#ffffff"/>
 
+    <!-- Begin Pattern Lab (Required for Pattern Lab to run properly) -->
+    {{ patternLabHead | raw }}
+    <!-- End Pattern Lab -->
+
+  </head>
+  <body class="{{ bodyClass }}"></body>
+</html>

--- a/styleguide/source/_patterns/01-atoms/button~vc-art.json
+++ b/styleguide/source/_patterns/01-atoms/button~vc-art.json
@@ -1,0 +1,11 @@
+{
+  "htmlClass": "vc-art",
+  "button": {
+    "href": "",
+    "info": "alt",
+    "text": "Art of Medicine Button",
+    "type": "button",
+    "style": "",
+    "size": ""
+  }
+}

--- a/styleguide/source/_patterns/01-atoms/button~vc-ethics.json
+++ b/styleguide/source/_patterns/01-atoms/button~vc-ethics.json
@@ -1,0 +1,11 @@
+{
+  "htmlClass": "vc-ethics",
+  "button": {
+    "href": "",
+    "info": "alt",
+    "text": "Ethics Close Up Button",
+    "type": "button",
+    "style": "",
+    "size": ""
+  }
+}

--- a/styleguide/source/_patterns/01-atoms/button~vc-gallery.json
+++ b/styleguide/source/_patterns/01-atoms/button~vc-gallery.json
@@ -1,0 +1,11 @@
+{
+  "htmlClass": "vc-gallery",
+  "button": {
+    "href": "",
+    "info": "alt",
+    "text": "Gallery Button",
+    "type": "button",
+    "style": "",
+    "size": ""
+  }
+}

--- a/styleguide/source/_patterns/01-atoms/headings.twig
+++ b/styleguide/source/_patterns/01-atoms/headings.twig
@@ -1,3 +1,4 @@
 {% for heading in headings %}
-  [01-atoms]-[heading]
+  {# [01-atoms]-[heading] #}
+  {% include "@atoms/heading.twig" %}
 {% endfor %}

--- a/styleguide/source/_patterns/01-atoms/headings~vc-art.json
+++ b/styleguide/source/_patterns/01-atoms/headings~vc-art.json
@@ -1,0 +1,35 @@
+{
+  "htmlClass": "vc-art",
+  "headings": [
+    {
+      "level": "1",
+      "text": "Heading Level 1",
+      "class": ""
+    },
+    {
+      "level": "2",
+      "text": "Heading Level 2",
+      "class": ""
+    },
+    {
+      "level": "3",
+      "text": "Heading Level 3",
+      "class": ""
+    },
+    {
+      "level": "4",
+      "text": "Heading Level 4",
+      "class": ""
+    },
+    {
+      "level": "5",
+      "text": "Heading Level 5",
+      "class": ""
+    },
+    {
+      "level": "6",
+      "text": "Heading Level 6",
+      "class": ""
+    }
+  ]
+}

--- a/styleguide/source/_patterns/01-atoms/headings~vc-ethics.json
+++ b/styleguide/source/_patterns/01-atoms/headings~vc-ethics.json
@@ -1,0 +1,35 @@
+{
+  "htmlClass": "vc-ethics",
+  "headings": [
+    {
+      "level": "1",
+      "text": "Heading Level 1",
+      "class": ""
+    },
+    {
+      "level": "2",
+      "text": "Heading Level 2",
+      "class": ""
+    },
+    {
+      "level": "3",
+      "text": "Heading Level 3",
+      "class": ""
+    },
+    {
+      "level": "4",
+      "text": "Heading Level 4",
+      "class": ""
+    },
+    {
+      "level": "5",
+      "text": "Heading Level 5",
+      "class": ""
+    },
+    {
+      "level": "6",
+      "text": "Heading Level 6",
+      "class": ""
+    }
+  ]
+}

--- a/styleguide/source/_patterns/01-atoms/headings~vc-gallery.json
+++ b/styleguide/source/_patterns/01-atoms/headings~vc-gallery.json
@@ -1,0 +1,35 @@
+{
+  "htmlClass": "vc-gallery",
+  "headings": [
+    {
+      "level": "1",
+      "text": "Heading Level 1",
+      "class": ""
+    },
+    {
+      "level": "2",
+      "text": "Heading Level 2",
+      "class": ""
+    },
+    {
+      "level": "3",
+      "text": "Heading Level 3",
+      "class": ""
+    },
+    {
+      "level": "4",
+      "text": "Heading Level 4",
+      "class": ""
+    },
+    {
+      "level": "5",
+      "text": "Heading Level 5",
+      "class": ""
+    },
+    {
+      "level": "6",
+      "text": "Heading Level 6",
+      "class": ""
+    }
+  ]
+}

--- a/styleguide/source/assets/scss/00-base/_colors.scss
+++ b/styleguide/source/assets/scss/00-base/_colors.scss
@@ -21,3 +21,80 @@ $black-20: #d1d3d4;
 $black-10: #E5E5E5;
 $black-05: #f1f1f1;
 $white: #ffffff;
+
+// Art of Medicine `vc-art` variables - Dark mode `Default`
+:root.vc-art {
+  --c-bg: #fff;
+  --c-text: #414042;
+  --c-link: var(--c-text);
+  --c-button-bg: #06847F;
+  --c-button-bg-hover: #CE4A22;
+  --c-button-text: var(--c-bg);
+  --c-footer-bg: var(--c-text);
+  --c-footer-label-bg: var(--c-bg);
+  --c-footer-label-text: var(--c-text);
+  --c-footer-text: var(--c-bg);
+  --c-footer-link: var(--c-bg);
+}
+
+// Ethics Close Up `vc-ethics` variables - Dark mode `Default`
+:root.vc-ethics,
+:root.vc-ethics[data-theme='dark'] {
+  --c-bg: #24282D;
+  --c-text: #fff;
+  --c-link: var(--c-text);
+  --c-button-bg: #191B1D;
+  --c-button-bg-hover: #0f1011;
+  --c-button-text: var(--c-text);
+  --c-footer-bg: var(--c-text);
+  --c-footer-label-bg: #2B2C33;
+  --c-footer-label-text: var(--c-text);
+  --c-footer-text: var(--c-bg);
+  --c-footer-link: var(--c-bg);
+}
+
+// Ethics Close Up `vc-ethics` variables - Light mode
+:root.vc-ethics[data-theme='light'] {
+  --c-bg: #ECECEC;
+  --c-text: #171A1D;
+  --c-link: var(--c-text);
+  --c-button-bg: #fff;
+  --c-button-bg-hover: #ddd;
+  --c-button-text: var(--c-text);
+  --c-footer-bg: var(--c-text);
+  --c-footer-label-bg: #fff;
+  --c-footer-label-text: var(--c-text);
+  --c-footer-text: var(--c-bg);
+  --c-footer-link: var(--c-bg);
+}
+
+// Gallery `vc-gallery` variables - Dark mode `Default`
+:root.vc-gallery,
+:root.vc-gallery[data-theme='dark'] {
+  --c-bg: #1D1E23;
+  --c-text: #fff;
+  --c-link: var(--c-text);
+  --c-button-bg: var(--c-text);
+  --c-button-bg-hover: #ECECEC;
+  --c-button-text: var(--c-bg);
+  --c-footer-bg: var(--c-text);
+  --c-footer-label-bg: #2B2C33;
+  --c-footer-label-text: var(--c-text);
+  --c-footer-text: var(--c-bg);
+  --c-footer-link: var(--c-bg);
+}
+
+// Gallery `vc-gallery` variables - Light mode
+:root.vc-gallery[data-theme='light'] {
+  --c-bg: #ECECEC;
+  --c-text: #171A1D;
+  --c-link: var(--c-text);
+  --c-button-bg: var(--c-text);
+  --c-button-bg-hover: #0f1113;
+  --c-button-text: #fff;
+  --c-footer-bg: var(--c-text);
+  --c-footer-label-bg: #fff;
+  --c-footer-label-text: var(--c-text);
+  --c-footer-text: var(--c-bg);
+  --c-footer-link: var(--c-bg);
+}

--- a/styleguide/source/assets/scss/00-base/_layout-variables.scss
+++ b/styleguide/source/assets/scss/00-base/_layout-variables.scss
@@ -1,1 +1,4 @@
 $max-width: 1600px;
+
+// Visual Content max width
+$vc-max-width: 1400px;

--- a/styleguide/source/assets/scss/00-base/_layout.scss
+++ b/styleguide/source/assets/scss/00-base/_layout.scss
@@ -12,10 +12,50 @@
   margin: 0 auto;
   @include gutter($padding-right-half...);
   @include gutter($padding-left-half...);
-  
+
   @include breakpoint($bp-med) {
     @include gutter($padding-right-full...);
     @include gutter($padding-left-full...);
   }
 }
 
+// Visual Content container styles
+.vc-container {
+  --container-width: #{$vc-max-width};
+  --container-padding: 2rem;
+  width: #{'min(100% - var(--container-padding), var(--container-width))'};
+  margin: 0 auto;
+
+  @include breakpoint($bp-med) {
+    --container-padding: 4rem;
+  }
+}
+
+// Set the default grid gap
+$gap: 2em;
+$row-gap: $gap;
+
+// Set the base grid layout
+@mixin basegrid($bp: $bp-med, $cols: 12, $col-gap: $gap, $row-gap: $gap) {
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: auto;
+  grid-column-gap: $col-gap;
+  grid-row-gap: $row-gap;
+
+  // Adjust global gap size at this bp
+  @include breakpoint($bp-large) {
+    grid-column-gap: $col-gap * 2;
+    grid-row-gap: $row-gap * 2;
+  }
+
+  // Adjust grid columns at variable bp
+  @include breakpoint($bp) {
+    grid-template-columns: repeat(#{$cols}, 1fr);
+  }
+}
+
+// Visual Content grid layout to container element
+.vc-grid {
+  @include basegrid();
+}

--- a/styleguide/source/assets/scss/00-base/_typography.scss
+++ b/styleguide/source/assets/scss/00-base/_typography.scss
@@ -7,13 +7,14 @@ body {
   color: $black-90;
   -webkit-font-smoothing: antialiased;
   margin: 0;
-  
+
   @include type($base-font-family, $base-font-size, $base-font-weight, $base-line-height);
 
   @include breakpoint($bp-med) {
     font-size: (calc($base-font-size / 16px)) * 110%;
     line-height: $base-line-height * 1.1;
   }
+
   @include breakpoint($bp-large) {
     font-size: (calc($base-font-size / 16px)) * 120%;
     line-height: $base-line-height * 1.2;
@@ -53,9 +54,11 @@ p,
   height: 1px;
   width: 1px;
   overflow: hidden;
+
   @if support-legacy-browser(ie, '7') {
     clip: rect(1px 1px 1px 1px); // IE6 and IE7 use the wrong syntax.
   }
+
   clip: rect(1px, 1px, 1px, 1px);
 }
 
@@ -85,7 +88,37 @@ sup {
   position: relative;
   line-height: 1;
   font-size: $base-font-size * 0.8;
+
   &:hover {
     cursor: pointer;
+  }
+}
+
+// Base styles for .vc-* pages
+:root.vc-art,
+:root.vc-ethics,
+:root.vc-gallery {
+  body {
+    background-color: var(--c-bg);
+    color: var(--c-text);
+
+    // Small adjustment to base font size at $bp-large for `vc-*` pages
+    @include breakpoint($bp-large) {
+      font-size: (calc($base-font-size / 16px)) * 110%;
+      line-height: $base-line-height * 1.2;
+    }
+  }
+
+  a:link,
+  a:visited {
+    color: var(--c-link);
+    text-decoration: underline;
+  }
+
+  a:active,
+  a:hover,
+  a:focus {
+    color: var(--c-link);
+    text-decoration: none;
   }
 }

--- a/styleguide/source/assets/scss/01-atoms/_button.scss
+++ b/styleguide/source/assets/scss/01-atoms/_button.scss
@@ -48,7 +48,7 @@ button {
   text-transform: none;
   letter-spacing: 0;
   box-shadow: inset 0 0 20px $orange;
-  
+
   &:active,
   &:hover,
   &:focus {
@@ -57,5 +57,43 @@ button {
     box-shadow: none;
     text-decoration: none;
     border-bottom: 0;
+  }
+}
+
+:root.vc-art,
+:root.vc-ethics,
+:root.vc-gallery {
+  button {
+    @include type($font-sans-serif, 0.75em, $font-weight-bold, 1.25);
+    transition: all 0.3s ease;
+    background: var(--c-button-bg);
+    color: var(--c-button-text);
+    letter-spacing: 0.075em;
+    text-transform: uppercase;
+    border: 0;
+    border-radius: 0;
+    cursor: pointer;
+    padding: 8px 22px;
+
+    &:link,
+    &:visited {
+      color: var(--c-button-text);
+      text-decoration: none;
+      border-bottom: 0;
+    }
+
+    &:active,
+    &:hover,
+    &:focus {
+      background: var(--c-button-bg-hover);
+      text-decoration: none;
+      border-bottom: 0;
+    }
+  }
+}
+
+:root.vc-ethics {
+  button {
+    padding: 15px 65px;
   }
 }

--- a/styleguide/source/assets/scss/01-atoms/_headings.scss
+++ b/styleguide/source/assets/scss/01-atoms/_headings.scss
@@ -7,6 +7,7 @@ h1,
   margin-bottom: 6px;
   margin-top: 2em;
 }
+
 h2,
 .joe__h2,
 %joe__h2 {
@@ -15,6 +16,7 @@ h2,
   margin-bottom: 6px;
   margin-top: 1.5em;
 }
+
 h3,
 .joe__h3,
 %joe__h3 {
@@ -23,6 +25,7 @@ h3,
   margin-bottom: 6px;
   margin-top: 1.25em;
 }
+
 h4,
 .joe__h4,
 %joe__h4 {
@@ -31,6 +34,7 @@ h4,
   margin-bottom: 6px;
   margin-top: 1em;
 }
+
 h5,
 .joe__h5,
 %joe__h5 {
@@ -39,6 +43,7 @@ h5,
   margin-bottom: 6px;
   margin-top: 1em;
 }
+
 h6,
 .joe__h6,
 %joe__h6 {
@@ -46,4 +51,57 @@ h6,
   @include type($font-sans-serif, 1em, $font-weight-bold, 1.25);
   margin-bottom: 6px;
   margin-top: .75em;
+}
+
+// Heading styles for all `vc-*` pages
+:root.vc-art,
+:root.vc-ethics,
+:root.vc-gallery {
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-family: $font-sans-serif;
+    font-weight: 700;
+    line-height: 1.3;
+    margin-block: 3rem 1.38rem;
+  }
+
+  h1 {
+    // Using clamp calculator to generate these values
+    // https://royalfig.github.io/fluid-typography-calculator/
+    font-size: clamp(2.75rem, 1.696rem + 4.680vw, 5.5rem);
+  }
+
+  h2 {
+    font-size: clamp(2rem, 1.444rem + 2.468vw, 3.45rem);
+  }
+
+  h3 {
+    font-size: clamp(1.75rem, 1.462rem + 1.276vw, 2.5rem);
+  }
+
+  h4 {
+    font-size: clamp(1.5rem, 1.308rem + 0.851vw, 2rem);
+  }
+
+  h5 {
+    font-size: clamp(1.25rem, 1.077rem + 0.765vw, 1.7rem);
+  }
+
+  h6 {
+    font-size: 1em;
+  }
+}
+
+// `vc-gallery` overrides
+:root.vc-gallery {
+  h1 {
+    font-family: $font-serif;
+    font-weight: 800;
+    font-size: clamp(2.75rem, 1.122rem + 7.234vw, 7rem);
+  }
 }


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

Please do not submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**

- N/A

**Jira Ticket**

- [JOE-20: Prototype Base Styles](https://palantir.atlassian.net/browse/JOE-20)

## Description

Establishing foundational style guide set up such as fonts, type scale, colors, typeset, and grid system for the new "visual content" content types.

Some new classes have been established in this PR to ensure our extended styles do not override the styles of AMA JOE. For instance, new `html` classes `vc-art`, `vc-ethics`,  and `vc-gallery` have been created for each content type. The `vc` stands for `visual content`. It will be used as a "prefix" in future components.

A data attribute called `data-theme` has been added as well. This will allow editors to switch from dark to light mode for the ethics and gallery content types.

## To Test

- [ ] Install and run style guide
    - Checkout this repo
    - `cd styleguide`
    - `composer install`
    - `nvm use 12`
    - `npm install`
    - `./node_modules/.bin/gulp serve`
    - Visit http://localhost:3000/ and see the styleguide
- [ ] Navigate to the [Headings vc-art](http://localhost:3000/?p=atoms-headings-vc-art), [Headings vc-ethics](http://localhost:3000/?p=atoms-headings-vc-ethics), and [Headings vc-gallery](http://localhost:3000/?p=atoms-headings-vc-gallery) atoms and review the heading typography. Ensure it looks good at all viewports.
    - To test the `light mode` you can add `"theme_mode": "light"` to the json files of ethics and gallery.
- [ ] Navigate to the [Button vc-art](http://localhost:3000/?p=atoms-button-vc-art), [Button vc-ethics](http://localhost:3000/?p=atoms-button-vc-ethics), and [Button vc-gallery](http://localhost:3000/?p=atoms-button-vc-gallery) atoms and review the heading typography. Ensure it looks good at all viewports.
    - To test the `light mode` you can add `"theme_mode": "light"` to the json files of ethics and gallery.
- [ ] Navigate to the "Changed files" tab and review:
    - The CSS variables that have been added.
    - The new container and grid mixin added.

## Visual Regressions

N/A

## Relevant Screenshots/GIFs

<img width="1111" alt="Screenshot 2023-10-12 at 2 39 31 PM" src="https://github.com/AmericanMedicalAssociation/joe-style-guide/assets/362529/0ab483e7-4d55-4dd7-8fc6-1937867bdb7c">

<img width="689" alt="Screenshot 2023-10-12 at 2 39 47 PM" src="https://github.com/AmericanMedicalAssociation/joe-style-guide/assets/362529/04e75385-9040-485b-ad46-a38fa4198961">


## Remaining Tasks

N/A


## Additional Notes

N/A
