### PR TITLE
JOE-21: Prototype visual content template

### DIFF
--- a/styleguide/source/_patterns/04-templates/vc-template.json
+++ b/styleguide/source/_patterns/04-templates/vc-template.json
@@ -1,0 +1,123 @@
+{
+  "htmlClass": "vc-art",
+  "htmlClass": "vc-ethics",
+  "theme_mode": "dark",
+  "header_wordmark": {
+    "title": "AMA Journal of Ethics",
+    "subtitle": "Illuminating the Art of Medicine",
+    "tm": true
+  },
+  "primary_navs": [
+    {
+      "href": "/",
+      "text": "Home"
+    },
+    {
+      "href": "/",
+      "text": "Issues"
+    },
+    {
+      "href": "/",
+      "text": "Articles"
+    },
+    {
+      "href": "/",
+      "text": "Cases"
+    },
+    {
+      "href": "/",
+      "text": "Art"
+    },
+    {
+      "href": "/",
+      "text": "Multimedia"
+    },
+    {
+      "href": "/",
+      "text": "CME"
+    }
+  ],
+  "search_label": {
+    "text": "Search AMA Journal of Ethics",
+    "id": "site-search"
+  },
+  "search_inputs": [
+    {
+      "type": "search",
+      "name": "Site Search",
+      "id": "site-search",
+      "placeholder": "Search"
+    },
+    {
+      "type": "submit",
+      "name": "Site Search Submit",
+      "id": "site-search-submit",
+      "value": "Search"
+    }
+  ],
+  "utility_navs": [
+    {
+      "href": "/",
+      "text": "Facebook",
+      "icon": "facebook"
+    },
+    {
+      "href": "/",
+      "text": "Twitter",
+      "icon": "twitter"
+    },
+    {
+      "href": "/",
+      "text": "YouTube",
+      "icon": "youtube"
+    },
+    {
+      "href": "/",
+      "text": "Instagram",
+      "icon": "instagram"
+    }
+  ],
+  "footer_wordmark": {
+    "title": "AMA Journal of Ethics",
+    "subtitle": "Illuminating the Art of Medicine",
+    "tm": "true"
+  },
+  "footer_logo": {
+    "alt": "American Medical Association",
+    "link": "https://www.ama-assn.org/"
+  },
+  "footer_navs": [
+    {
+      "href": "/",
+      "text": "About"
+    },
+    {
+      "href": "/",
+      "text": "Conditions of Use"
+    },
+    {
+      "href": "/",
+      "text": "Privacy Policy"
+    },
+    {
+      "href": "/",
+      "text": "Cookie Settings"
+    },
+    {
+      "href": "/",
+      "text": "FAQs"
+    },
+    {
+      "href": "/",
+      "text": "Contact"
+    }
+  ],
+  "copyright": "American Medical Association. All Rights Reserved. ISSN 2376-6980",
+  "offset_center": {
+    "page_content": {
+      "placeholder": {
+        "text": "Page content placeholder"
+      }
+    }
+  }
+}

--- a/styleguide/source/_patterns/04-templates/vc-template.twig
+++ b/styleguide/source/_patterns/04-templates/vc-template.twig
@@ -1,0 +1,17 @@
+{% include '@atoms/skip-nav.twig' %}
+
+{% block header %}
+  {% include "@organisms/vc-header.twig" %}
+{% endblock %}
+<main id="main-content" role="main">
+  <article class="vc-article">
+    {% block pageContent %}
+      {% set placeholder = offset_center.page_content.placeholder %}
+      {% include '@base/placeholder.twig' %}
+    {% endblock %}
+  </article>
+</main>
+
+{% block footer %}
+  {% include "@organisms/vc-footer.twig" %}
+{% endblock %}</div>

--- a/styleguide/source/assets/scss/00-base/_placeholder.scss
+++ b/styleguide/source/assets/scss/00-base/_placeholder.scss
@@ -1,5 +1,8 @@
 .ama__placeholder {
   @include type($font-serif, 1.888em, $font-weight-medium, 1.1176470588);
+  display: flex;
+  justify-content: center;
+  align-items: center;
   color: $black-20;
   min-height: 50px;
   border: 4px dashed $black-20;


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

Please do not submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**

- N/A

**Jira Ticket**

- [JOE-21: Prototype Visual Template](https://palantir.atlassian.net/browse/JOE-21)


## Description

This ticket is for creating the default visual content template which will be used for each content type.

## To Test

- [x] Navigate to the [VC Template](http://localhost:3000/?p=templates-vc-template) and review the markup, scss, and json
- [x] Ensure the template looks good at all viewports
- [x] Ensure the site header functions as expected
- [x] Change `theme_mode` to `light` in the template json file and ensure the theme switches to light.

## Visual Regressions

N/A

## Relevant Screenshots/GIFs

<img width="1553" alt="Screenshot 2023-10-17 at 10 10 04 AM" src="https://github.com/AmericanMedicalAssociation/joe-style-guide/assets/362529/2b0a6194-78cb-4229-a324-eb964e932a07">

## Remaining Tasks

N/A

## Additional Notes

N/A
