### PR TITLE
JOE-192: Gallery mobile horizontal alignment

### DIFF
--- a/styleguide/source/assets/scss/00-base/_helpers.scss
+++ b/styleguide/source/assets/scss/00-base/_helpers.scss
@@ -49,12 +49,12 @@
 
   &::before {
     content: '';
+    display: block;
     position: absolute;
     top: 0;
-    left: 50%;
+    left: calc(50% - 10px);
     width: 20px;
     height: 10rem;
-    transform: translateX(-50%);
     background-image: url('../images/vc/bg-gallery-pattern--dark.svg');
     background-repeat: repeat;
     background-position: center top;

--- a/styleguide/source/assets/scss/00-base/_slick.scss
+++ b/styleguide/source/assets/scss/00-base/_slick.scss
@@ -232,8 +232,12 @@
       background-repeat: no-repeat;
       background-size: contain;
       padding: 0;
-      width: 4rem;
+      width: 3rem;
       height: 2rem;
+
+      @include breakpoint($bp-small) {
+        width: 4rem;
+      }
 
       &:active,
       &:focus,
@@ -249,7 +253,6 @@
         opacity: 0;
         visibility: hidden;
         transform: translateY(100%);
-        overflow: hidden;
       }
 
       svg g {

--- a/styleguide/source/assets/scss/03-organisms/_vc-hero-gallery.scss
+++ b/styleguide/source/assets/scss/03-organisms/_vc-hero-gallery.scss
@@ -33,7 +33,6 @@
   @include type($font-serif, 1em, $font-weight-bold, 1);
   text-transform: uppercase;
   letter-spacing: 0.1em;
-  margin-inline-end: 2rem;
 }
 
 :root.vc-gallery {
@@ -129,12 +128,14 @@
   justify-content: center;
   align-items: center;
   gap: 1rem;
+  padding-inline: 1rem;
 }
 
 .vc-hero-gallery__nav-label {
   @include type($font-sans-serif, 0.8em, $font-weight-medium, 1);
   text-transform: uppercase;
   letter-spacing: 0.1em;
+  text-align: center;
 
   @include breakpoint($bp-small) {
     font-size: 1em;

--- a/styleguide/source/assets/scss/03-organisms/_vc-horizontal-gallery.scss
+++ b/styleguide/source/assets/scss/03-organisms/_vc-horizontal-gallery.scss
@@ -69,6 +69,7 @@
   justify-content: center;
   align-items: center;
   gap: 1rem;
+  padding-inline: 1rem;
 }
 
 .vc-horizontal-gallery__controls-label {


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

Please do not submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Jira Ticket**

- [JOE-192: Gallery mobile horizontal alignment](https://palantir.atlassian.net/browse/JOE-192)


## Description

Several alignment issues reported by the client. [See ticket for screenshot details](https://palantir.atlassian.net/browse/JOE-192).


## To Test
Navigate to the [Gallery Page](http://localhost:3000/?p=pages-vc-gallery-dark) and review:
- [x] Verify the vertical design "rod/pattern" is centered at mobile/tablet/desktop.
- [x] Verify the "Exhibition Galleries" label and navigation arrows are centered at mobile/tablet/desktop.
- [x] Verify the “Art Exhibition” label in the hero is centered at mobile/tablet/desktop.

## Visual Regressions

N/A


## Relevant Screenshots/GIFs

“Art Exhibition” label
<img width="691" alt="Screenshot 2023-12-04 at 1 35 49 PM" src="https://github.com/AmericanMedicalAssociation/joe-style-guide/assets/362529/68953baf-ff9c-40f6-8757-94687f99f430">

"Exhibition Galleries" label
<img width="365" alt="Screenshot 2023-12-04 at 1 36 59 PM" src="https://github.com/AmericanMedicalAssociation/joe-style-guide/assets/362529/69b92cb4-3d38-4929-9226-290675ca40cb">

Vertical design "rod/pattern"
<img width="386" alt="Screenshot 2023-12-04 at 1 36 28 PM" src="https://github.com/AmericanMedicalAssociation/joe-style-guide/assets/362529/9307b06c-0399-48f5-997d-f12dc37bfe23">

## Remaining Tasks

N/A


## Additional Notes

N/A