### PR TITLE
JOE-190: Sticky nav causing hitch on scroll

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_vc-header.scss
+++ b/styleguide/source/assets/scss/03-organisms/_vc-header.scss
@@ -1,4 +1,11 @@
 // Visual Content header
+
+:root[class*='vc-'] {
+  .joe__sticky-header {
+    padding-top: 0;
+  }
+}
+
 :root[class*='vc-'] .vc-header {
 
   .joe__wordmark a {
@@ -57,16 +64,28 @@
 }
 
 // Art of Medicine header overrides
-:root.vc-art .vc-header {
-  .joe__wordmark a {
-    color: var(--c-hero-text);
+:root.vc-art {
+  padding-block-start: 3.2rem;
+
+  @include breakpoint($bp-small) {
+    padding-block-start: 3.8rem;
   }
 
-  .vc-header__action-button svg {
+  @include breakpoint($bp-med) {
+    padding-block-start: 4.8rem;
+  }
 
-    path,
-    circle {
-      stroke: var(--c-hero-text);
+  .vc-header {
+    .joe__wordmark a {
+      color: var(--c-hero-text);
+    }
+  
+    .vc-header__action-button svg {
+  
+      path,
+      circle {
+        stroke: var(--c-hero-text);
+      }
     }
   }
 }
@@ -84,7 +103,10 @@
 }
 
 .vc-header {
-  position: relative;
+  position: fixed;
+  left: 0;
+  right: 0;
+  top: 0;
   padding-block: 0.5rem;
   z-index: 100;
 
@@ -97,10 +119,6 @@
   .joe__sticky-header & {
     background-color: var(--c-bg);
     box-shadow: 0 0 50px rgba($black, 0.2);
-    position: fixed;
-    left: 0;
-    right: 0;
-    top: 0;
 
     // Art of Medicine header overrides
     :root.vc-art & {


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

Please do not submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**

- N/A

**Jira Ticket**

- [JOE-190: Sticky nav causing hitch on scroll](https://palantir.atlassian.net/browse/JOE-190)


## Description

For both the dark and light mode, there seems to be a downward jerkiness when you initiate scrolling on this page in the desktop format. Almost as if the header is trying to adjust/move with the first scroll. [See ticket for screenshots of the issue](https://palantir.atlassian.net/browse/JOE-190).


## To Test

- [x] Navigate to each Visual Content page example (e.g. [Gallery page](http://localhost:3000/?p=pages-vc-gallery-light)) and ensure there is no more hitch with the sticky header nav when scrolling down from the top.

## Visual Regressions

N/A


## Relevant Screenshots/GIFs

![nav-scroll](https://github.com/AmericanMedicalAssociation/joe-style-guide/assets/362529/9b32efe0-52ea-4203-ab00-6b0d97785e31)


## Remaining Tasks

N/A


## Additional Notes

N/A
