### PR TITLE
JOE-191: "Back to Galleries" button

### DIFF
--- a/styleguide/source/_meta/_01-foot.twig
+++ b/styleguide/source/_meta/_01-foot.twig
@@ -29,6 +29,7 @@
 <script src="../../assets/js/vc-featured-audio-visuals.min.js"></script>
 <script src="../../assets/js/vc-is-zoomed.js"></script>
 <script src="../../assets/js/vc-featured-audio.js"></script>
+<script src="../../assets/js/vc-back-to.js"></script>
 {# Modernizr #}
 {# Contains: cssgrid, css animations, flexbox #}
 <script src="../../assets/js/modernizr-custom.js"></script></body></html>

--- a/styleguide/source/_patterns/00-base/icons/icon-up-arrow.svg
+++ b/styleguide/source/_patterns/00-base/icons/icon-up-arrow.svg
@@ -1,0 +1,1 @@
+<svg fill="none" height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><path clip-rule="evenodd" d="m8.91055 1.65728v13.59692h-1v-13.59595l-5.20468 5.18649-.70587-.70834 6.1579-6.13636846.2535.25439046.25403-.253144 6.15787 6.136352-.7083.70587z" fill="#fff" fill-rule="evenodd"/></svg>

--- a/styleguide/source/_patterns/03-organisms/vc-hero-gallery/vc-hero-gallery.twig
+++ b/styleguide/source/_patterns/03-organisms/vc-hero-gallery/vc-hero-gallery.twig
@@ -10,7 +10,7 @@
       </div>
     </div>
   </div>
-  <div class="vc-hero-gallery__nav vc-gallery__items">
+  <div id="vc-galleries" class="vc-hero-gallery__nav vc-gallery__items">
     {% for item in hero.gallery_nav %}
       <a class="vc-hero-gallery__anchor" href="{{ item.href }}">
         {% set image = item.image %}

--- a/styleguide/source/_patterns/04-templates/vc-template.twig
+++ b/styleguide/source/_patterns/04-templates/vc-template.twig
@@ -28,8 +28,14 @@
 {% endblock %}
 
 {% if htmlClass == "vc-gallery" %}
-  <a href="#vc-galleries" id="vc-back-to-galleries" class="button">
+  <a href="#vc-galleries" id="vc-back-to-galleries" class="button vc-back-to-button">
     {% include "@base/icons/icon-up-arrow.svg" %}
     Back to Galleries
+  </a>
+{% endif %}
+{% if htmlClass == "vc-ethics" %}
+  <a href="#top" id="vc-back-to-top" class="button vc-back-to-button">
+    {% include "@base/icons/icon-up-arrow.svg" %}
+    Back to Top
   </a>
 {% endif %}</div>

--- a/styleguide/source/_patterns/04-templates/vc-template.twig
+++ b/styleguide/source/_patterns/04-templates/vc-template.twig
@@ -28,5 +28,8 @@
 {% endblock %}
 
 {% if htmlClass == "vc-gallery" %}
-  <a href="#vc-galleries" id="vc-back-to-galleries" class="button">Back to Galleries</a>
+  <a href="#vc-galleries" id="vc-back-to-galleries" class="button">
+    {% include "@base/icons/icon-up-arrow.svg" %}
+    Back to Galleries
+  </a>
 {% endif %}</div>

--- a/styleguide/source/_patterns/04-templates/vc-template.twig
+++ b/styleguide/source/_patterns/04-templates/vc-template.twig
@@ -25,4 +25,8 @@
 
 {% block footer %}
   {% include "@organisms/vc-footer/vc-footer.twig" %}
-{% endblock %}</div>
+{% endblock %}
+
+{% if htmlClass == "vc-gallery" %}
+  <a href="#vc-galleries" id="vc-back-to-galleries" class="button">Back to Galleries</a>
+{% endif %}</div>

--- a/styleguide/source/assets/js/vc-back-to.js
+++ b/styleguide/source/assets/js/vc-back-to.js
@@ -1,0 +1,93 @@
+/**
+ * @file
+ * Facets and filters
+ *
+ * JavaScript should be made compatible with libraries other than jQuery by
+ * wrapping it with an "anonymous closure". See:
+ * - https://drupal.org/node/1446420
+ * - http://www.adequatelygood.com/2010/3/JavaScript-Module-Pattern-In-Depth
+ */
+
+(function ($, Drupal) {
+  Drupal.behaviors.vc_back_to = {
+    attach: function (context, settings) {
+      const vcGalleries = document.getElementById('vc-galleries');
+      const vcBackToGalleries = document.getElementById('vc-back-to-galleries');
+
+      const vcEthicsHero = document.querySelector('.vc-hero-ethics');
+      const vcBackToTop = document.getElementById('vc-back-to-top');
+
+      // Find the dimensions of pastViewport
+      const pastViewport = function (e) {
+        const distance = e.getBoundingClientRect();
+        return distance.bottom >= 0;
+      };
+
+      // Set past galleries view func
+      function pastGalleriesView() {
+        if (pastViewport(vcGalleries)) {
+          // If in view
+          vcBackToGalleries.classList.remove('is-visible');
+        } else {
+          vcBackToGalleries.classList.add('is-visible');
+        }
+      }
+
+      if (vcGalleries) {
+        // Set throttle variables
+        let lastScrollPosition = 0;
+        let throttle = false;
+
+        window.addEventListener(
+          'scroll',
+          () => {
+            // Set lastScrollPosition to window.scrollY
+            lastScrollPosition = window.scrollY;
+            // Throttle scroll behavior
+            if (!throttle) {
+              setTimeout(() => {
+                pastGalleriesView(lastScrollPosition);
+                throttle = false;
+              }, 25);
+            }
+            throttle = true;
+          },
+          false
+        );
+      }
+
+      // Set past hero view func
+      function pastHeroView() {
+        if (pastViewport(vcEthicsHero)) {
+          // If in view
+          vcBackToTop.classList.remove('is-visible');
+        } else {
+          vcBackToTop.classList.add('is-visible');
+        }
+      }
+
+      if (vcEthicsHero) {
+        // Set throttle variables
+        let lastScrollPosition = 0;
+        let throttle = false;
+
+        window.addEventListener(
+          'scroll',
+          () => {
+            // Set lastScrollPosition to window.scrollY
+            lastScrollPosition = window.scrollY;
+            // Throttle scroll behavior
+            if (!throttle) {
+              setTimeout(() => {
+                pastHeroView(lastScrollPosition);
+                throttle = false;
+              }, 25);
+            }
+            throttle = true;
+          },
+          false
+        );
+      }
+    },
+  };
+})(jQuery, Drupal);

--- a/styleguide/source/assets/js/vc-hero-gallery.js
+++ b/styleguide/source/assets/js/vc-hero-gallery.js
@@ -17,12 +17,7 @@
       // Find the dimensions of pastViewport
       const pastViewport = function (e) {
         const distance = e.getBoundingClientRect();
-        return (
-          distance.left >= 0 &&
-          distance.right <=
-            (window.innerWidth || document.documentElement.clientWidth) &&
-          distance.bottom >= 0
-        );
+        return distance.bottom >= 0;
       };
 
       // Set inView

--- a/styleguide/source/assets/js/vc-hero-gallery.js
+++ b/styleguide/source/assets/js/vc-hero-gallery.js
@@ -12,23 +12,6 @@
   Drupal.behaviors.vc_hero_gallery = {
     attach: function (context, settings) {
       const vcHeroGallery = document.querySelector('.vc-hero-gallery');
-      const vcBackToGalleries = document.getElementById('vc-back-to-galleries');
-
-      // Find the dimensions of pastViewport
-      const pastViewport = function (e) {
-        const distance = e.getBoundingClientRect();
-        return distance.bottom >= 0;
-      };
-
-      // Set inView
-      function pastView() {
-        if (pastViewport(vcHeroGallery)) {
-          // If in view
-          vcBackToGalleries.classList.remove('is-visible');
-        } else {
-          vcBackToGalleries.classList.add('is-visible');
-        }
-      }
 
       if (vcHeroGallery) {
         $('.vc-hero-gallery__nav').slick({
@@ -53,28 +36,6 @@
             },
           ],
         });
-
-        // Set throttle variables
-        let lastScrollPosition = 0;
-        let throttle = false;
-
-        window.addEventListener(
-          'scroll',
-          () => {
-            // Set lastScrollPosition to window.scrollY
-            lastScrollPosition = window.scrollY;
-            // Throttle scroll behavior
-            if (!throttle) {
-              setTimeout(() => {
-                pastView(lastScrollPosition);
-                throttle = false;
-                console.log('scrolling');
-              }, 25);
-            }
-            throttle = true;
-          },
-          false
-        );
       }
     },
   };

--- a/styleguide/source/assets/js/vc-hero-gallery.js
+++ b/styleguide/source/assets/js/vc-hero-gallery.js
@@ -11,8 +11,29 @@
 (function ($, Drupal) {
   Drupal.behaviors.vc_hero_gallery = {
     attach: function (context, settings) {
-
       const vcHeroGallery = document.querySelector('.vc-hero-gallery');
+      const vcBackToGalleries = document.getElementById('vc-back-to-galleries');
+
+      // Find the dimensions of pastViewport
+      const pastViewport = function (e) {
+        const distance = e.getBoundingClientRect();
+        return (
+          distance.left >= 0 &&
+          distance.right <=
+            (window.innerWidth || document.documentElement.clientWidth) &&
+          distance.bottom >= 0
+        );
+      };
+
+      // Set inView
+      function pastView() {
+        if (pastViewport(vcHeroGallery)) {
+          // If in view
+          vcBackToGalleries.classList.remove('is-visible');
+        } else {
+          vcBackToGalleries.classList.add('is-visible');
+        }
+      }
 
       if (vcHeroGallery) {
         $('.vc-hero-gallery__nav').slick({
@@ -32,12 +53,34 @@
               settings: {
                 slidesToShow: 1,
                 slidesToScroll: 1,
-                variableWidth: false
-              }
-            }
-          ]
+                variableWidth: false,
+              },
+            },
+          ],
         });
+
+        // Set throttle variables
+        let lastScrollPosition = 0;
+        let throttle = false;
+
+        window.addEventListener(
+          'scroll',
+          () => {
+            // Set lastScrollPosition to window.scrollY
+            lastScrollPosition = window.scrollY;
+            // Throttle scroll behavior
+            if (!throttle) {
+              setTimeout(() => {
+                pastView(lastScrollPosition);
+                throttle = false;
+                console.log('scrolling');
+              }, 25);
+            }
+            throttle = true;
+          },
+          false
+        );
       }
-    }
+    },
   };
 })(jQuery, Drupal);

--- a/styleguide/source/assets/scss/00-base/_typography.scss
+++ b/styleguide/source/assets/scss/00-base/_typography.scss
@@ -97,6 +97,7 @@ sup {
 // Base styles for .vc-* pages
 :root[class*='vc-'] {
   scroll-behavior: smooth;
+  scroll-padding: 25px;
 
   body {
     background-color: var(--c-bg);

--- a/styleguide/source/assets/scss/01-atoms/_button.scss
+++ b/styleguide/source/assets/scss/01-atoms/_button.scss
@@ -93,6 +93,41 @@ button {
       border-bottom: 0;
     }
   }
+
+  // Back to button
+  a.vc-back-to-button {
+    transition: all 0.3s ease;
+    position: fixed;
+    bottom: 1rem;
+    right: 1rem;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 0.5rem;
+    box-shadow: 0 0 50px rgba($black, 0.2);
+    z-index: 1;
+    opacity: 0;
+    visibility: hidden;
+  
+    @include breakpoint($bp-small) {
+      bottom: 2rem;
+      right: 2rem;
+    }
+  
+    svg {
+      width: 1rem;
+      height: 1rem;
+    
+      path {
+        fill: var(--c-button-text);
+      }
+    }
+  
+    &.is-visible {
+      opacity: 1;
+      visibility: visible;
+    }
+  }
 }
 
 :root.vc-ethics {

--- a/styleguide/source/assets/scss/03-organisms/_vc-hero-gallery.scss
+++ b/styleguide/source/assets/scss/03-organisms/_vc-hero-gallery.scss
@@ -140,3 +140,24 @@
     font-size: 1em;
   }
 }
+
+#vc-back-to-galleries {
+  transition: all 0.3s ease;
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  box-shadow: 0 0 50px rgba($black, 0.2);
+  z-index: 1;
+  opacity: 0;
+  visibility: hidden;
+
+  @include breakpoint($bp-small) {
+    bottom: 2rem;
+    right: 2rem;
+  }
+
+  &.is-visible {
+    opacity: 1;
+    visibility: visible;
+  }
+}

--- a/styleguide/source/assets/scss/03-organisms/_vc-hero-gallery.scss
+++ b/styleguide/source/assets/scss/03-organisms/_vc-hero-gallery.scss
@@ -146,6 +146,10 @@
   position: fixed;
   bottom: 1rem;
   right: 1rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
   box-shadow: 0 0 50px rgba($black, 0.2);
   z-index: 1;
   opacity: 0;
@@ -154,6 +158,15 @@
   @include breakpoint($bp-small) {
     bottom: 2rem;
     right: 2rem;
+  }
+
+  svg {
+    width: 1rem;
+    height: 1rem;
+  
+    path {
+      fill: var(--c-button-text);
+    }
   }
 
   &.is-visible {

--- a/styleguide/source/assets/scss/03-organisms/_vc-hero-gallery.scss
+++ b/styleguide/source/assets/scss/03-organisms/_vc-hero-gallery.scss
@@ -140,37 +140,3 @@
     font-size: 1em;
   }
 }
-
-#vc-back-to-galleries {
-  transition: all 0.3s ease;
-  position: fixed;
-  bottom: 1rem;
-  right: 1rem;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 0.5rem;
-  box-shadow: 0 0 50px rgba($black, 0.2);
-  z-index: 1;
-  opacity: 0;
-  visibility: hidden;
-
-  @include breakpoint($bp-small) {
-    bottom: 2rem;
-    right: 2rem;
-  }
-
-  svg {
-    width: 1rem;
-    height: 1rem;
-  
-    path {
-      fill: var(--c-button-text);
-    }
-  }
-
-  &.is-visible {
-    opacity: 1;
-    visibility: visible;
-  }
-}


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

Please do not submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**

- N/A

**Jira Ticket**

- [JOE-191: "Back to Galleries" button](https://palantir.atlassian.net/browse/JOE-191)


## Description

For both the dark and light mode is that once you’re in a specific gallery within an exhibition, it’s not clear/obvious how you navigate back to the galleries carousel to view other galleries. [See ticket for more details about the issue](https://palantir.atlassian.net/browse/JOE-191).


## To Test

- [x] Navigate to the [Gallery pages](http://localhost:3000/?p=pages-vc-gallery-dark) and verify that a "Back to Galleries" button appears in the bottom right corner of the page once you scroll past the "Exhibition Galleries" navigation.
    - [x] Verify that you are scrolled up to the "Exhibition Galleries" navigation when you click on the button (not the top of the page).
    - [x] Verify this button appears properly at all viewports
- [x] Navigate to the [Ethics pages](http://localhost:3000/?p=pages-vc-ethics-dark) and verify that a "Back to Top" button appears in the bottom right corner of the page once you scroll past the "Hero" component.
    - [x] Verify that you are scrolled up to the top of the page when you click on the button.
    - [x] Verify this button appears properly at all viewports

## Visual Regressions

N/A


## Relevant Screenshots/GIFs

![back-to-galleries](https://github.com/AmericanMedicalAssociation/joe-style-guide/assets/362529/adefb40c-aa5d-4993-9111-5cd4c15d5cf7)

## Remaining Tasks

N/A


## Additional Notes

N/A
