### PR TITLE
JOE-206, 207: Video tabs updates

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_vc-featured-media.scss
+++ b/styleguide/source/assets/scss/03-organisms/_vc-featured-media.scss
@@ -65,6 +65,7 @@
 .vc-featured-media__video {
   position: relative;
   aspect-ratio: 16 / 9;
+  width: 100%;
 
   iframe,
   object {

--- a/styleguide/source/assets/scss/03-organisms/_vc-video-tabs.scss
+++ b/styleguide/source/assets/scss/03-organisms/_vc-video-tabs.scss
@@ -32,7 +32,7 @@
 
 .vc-video-tabs__group [role='tablist'] {
   padding: 0;
-  margin: 0;
+  margin: 0 0 0.5rem;
 
   @include breakpoint($bp-med) {
     flex-basis: 30%;
@@ -41,8 +41,10 @@
   }
 
   li {
-    @include breakpoint($bp-med) {
-      border-bottom: 1px solid var(--c-text);
+    border-bottom: 1px solid var(--c-text);
+
+    &:last-child {
+      border-bottom: 0;
     }
   }
 
@@ -55,7 +57,6 @@
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    border: 1px solid var(--c-text);
     padding: 0.5rem 1rem;
 
     @include breakpoint($bp-med) {

--- a/styleguide/source/assets/scss/03-organisms/_vc-video-tabs.scss
+++ b/styleguide/source/assets/scss/03-organisms/_vc-video-tabs.scss
@@ -99,6 +99,7 @@
 .vc-video-tabs__group [role='tabpanel'] {
   position: relative;
   aspect-ratio: 16 / 9;
+  width: 100%;
 
   iframe,
   object {


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

Please do not submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**

- N/A

**Jira Ticket**

- [JOE-206, 207: Video tabs updates](https://issues.ama-assn.org/browse/EWL-XXXX)


## Description

* In the mobile format, the video option is not sized with the width of the screen so as you scroll down the entire page, it is not “stable” as there is side to side shifting.
* Preference to have the list of video options in tablet/mobile formats not bound with the thin black line margin through all margin borders. There should only be a line separating video options as it is in the desktop format.

## To Test

- [x] Navigate to the Art of Medicine page on a mobile device and verify the embedded video displays correctly.
- [x] Verify the video tabs only display border underlines at mobile.

## Visual Regressions

N/A

## Relevant Screenshots/GIFs

![IMG_27102827D46A-1](https://github.com/AmericanMedicalAssociation/joe-style-guide/assets/362529/c41afc78-7e33-4c97-abe9-669f6ce8cc69)


## Remaining Tasks

N/A

## Additional Notes

N/A
