### PR TITLE
Joe 212 scroll and zoom

### DIFF
--- a/styleguide/source/_meta/_01-foot.twig
+++ b/styleguide/source/_meta/_01-foot.twig
@@ -7,6 +7,7 @@
 <script src="../../assets/js/slick.min.js"></script>
 <script src="../../assets/js/micromodal.min.js"></script>
 <script src="../../assets/js/BeerSlider.unmin.js"></script>
+<script src="../../assets/js/vendor/gsap.min.js"></script>
 <script src="../../assets/js/nav.js"></script>
 <script src="../../assets/js/tool-drawer.js"></script>
 <script src="../../assets/js/chosen.jquery.min.js"></script>

--- a/styleguide/source/_patterns/03-organisms/vc-scroll-zoom/vc-scroll-zoom.json
+++ b/styleguide/source/_patterns/03-organisms/vc-scroll-zoom/vc-scroll-zoom.json
@@ -1,74 +1,91 @@
 {
   "htmlClass": "vc-ethics",
   "theme_mode": "dark",
-  "scroll_zoom": {
-    "image": "<img srcset='../../assets/images/vc/bg-hero-ethics--small.jpg  640w, ../../assets/images/vc/bg-hero-ethics--medium.jpg  1280w, ../../assets/images/vc/bg-hero-ethics--large.jpg 2560w' sizes='100vw' src='../../assets/images/vc/bg-hero-ethics--large.jpg' alt='Alt text'>",
-    "captions": [
-      {
-        "description": "<p>One of the most recognized paintings of Western medicine, Luke Fildes’ The Doctor was hailed as an ideal representation of caring when it was first exhibited at the Royal Academy of Art in 1891. Henry Tate wanted an English painting worthy of a new gallery in his name, but he left the subject matter of his commission to Fildes.</p>",
-        "position_right": false,
-        "index": 0
-      },
-      {
-        "description": "<p>As witness to a doctor’s care of his son who died of typhoid fever, Fildes wanted to “put on record the status of the doctor.”<sup>1</sup> Fildes’ surviving son wrote that his father “must have thought a great deal on the subject for…. it was the easiest and quickest painted of his big pictures.”</p>",
-        "position_right": false,
-        "index": 1
-      },
-      {
-        "description": "<p>Light has long symbolized hope and wisdom and a table lamp provides the primary illumination in this otherwise dimly lit scene. At first glance, the doctor and his young patient seem to be the only figures present.</p>",
-        "position_right": true,
-        "index": 2
-      },
-      {
-        "description": "<p>Nearly centered in the painting, the child lies in a makeshift bed of <sup>2</sup> mismatched chairs. An outstretched left arm hangs over the pillow, signaling a certain precariousness of the moment. The doctor’s presence signals some hope that the child will recover.</p>",
-        "position_right": false,
-        "index": 3
-      },
-      {
-        "description": "<p>Not sitting tiredly despite a night vigil, the doctor is illuminated in a forward-leaning position, chin in his hand. His stare is not a casual gaze, but one that is intensely and diagnostically trained on the child.</p>",
-        "position_right": true,
-        "index": 4
-      },
-      {
-        "description": "<p>A fisherman’s net hardly visible in the rafters represents manual labor, presumably a means by which the father of the child supports his family. This labor is juxtaposed to the doctor’s intellectual and professional work, which apparently supersedes the power of manual labor and that of the child’s parents.</p>",
-        "position_right": true,
-        "index": 5
-      },
-      {
-        "description": "<p>The child’s parents recede into the background, reinforcing their helplessness to affect their child’s fate. A dawn light filtering through the window reveals the father comforting the mother, casting further uncertainty on their child’s immediate future.</p>",
-        "position_right": false,
-        "index": 6
-      },
-      {
-        "description": "<p>Despite the painting’s depiction, a doctor’s presence in a working-class home is more idealized than reality. During the Victorian era, such house calls were generally afforded to those with wealth and power.</p>",
-        "position_right": false,
-        "index": 7
-      },
-      {
-        "description": "<p>Prior paintings of the ill at home also never depicted a medical practitioner with a bottle of medicine, which was previously associated with only familial caregivers.<sup>3</sup> The content of this bottle is unknown, but it wasn’t a typhoid vaccine, since none existed until 1896.<sup>4</sup></p>",
-        "position_right": true,
-        "index": 8
-      },
-      {
-        "description": "<p>On the floor, 2 fragments of paper are probably the filled prescription for the medicine.<sup>5</sup> The torn and crumpled prescription suggests that the medicine has been dispensed, but its effect remains an open question.</p>",
-        "position_right": false,
-        "index": 9
-      },
-      {
-        "description": "<p>It is notable that the stethoscope, thermometer, and other advances of medical science are nowhere to be seen. Instead, a cup and spoon are the instruments presumably used to deliver medicine to the sick child.<sup>6</sup> Fildes seemed more intent on focusing our attention on the art than the science of medicine.</p>",
-        "position_right": true,
-        "index": 10
-      },
-      {
-        "description": "<p>Despite its idealized representation of doctoring or likely because of it, The Doctor struck a resonant chord with the public and profession alike. An engraved print of the painting sold more than 1 million copies in the United States. ”A library of books written in your honour would not do what this picture has done and will do for the medical profession in making the hearts of our fellow men warm to us with confidence and affection,” wrote a physician critic in 1892.<sup>7</sup></p>",
-        "position_right": false,
-        "index": 11
-      },
-      {
-        "description": "<p>Given its popular and professional appeal, The Doctor has been employed over the years to depict the practice of medicine in highly public and sometimes contradictory ways.</p>",
-        "position_right": false,
-        "index": 12
-      }
-    ]
-  }
+  "startingcoords_desktop": "330 183 864 864",
+  "startingcoords_mobile": "365 254 728 728",
+  "startingcoords_tablet": "193 114 1062 1062",
+  "image": "../../assets/images/vc/bg-hero-ethics--large.jpg",
+  "alt_text": "Luke Fildes’ painting 'The Doctor'",
+  "captions": [
+    {
+      "description": "<p>One of the most recognized paintings of Western medicine, Luke Fildes’ The Doctor was hailed as an ideal representation of caring when it was first exhibited at the Royal Academy of Art in 1891. Henry Tate wanted an English painting worthy of a new gallery in his name, but he left the subject matter of his commission to Fildes.</p>",
+      "position_right": false,
+      "index": 0,
+      "desktop": "",
+      "tablet": "",
+      "mobile": ""
+    },
+    {
+      "description": "<p>As witness to a doctor’s care of his son who died of typhoid fever, Fildes wanted to put on record the status of the doctor.</p>",
+      "position_right": true,
+      "index": 1,
+      "desktop": "563 276 305 305",
+      "tablet": "341 240 743 743",
+      "mobile": "438 364 549 549"
+    },
+    {
+      "description": "<p>Light has long symbolized hope and wisdom and a table lamp provides the primary illumination in this otherwise dimly lit scene. At first glance, the doctor and his young patient seem to be the only figures present.</p>",
+      "position_right": false,
+      "index": 2,
+      "desktop": "51 320 278 278",
+      "tablet": "101 341 186 186",
+      "mobile": "81 364 219 219"
+    },
+    {
+      "description": "<p>Nearly centered in the painting, the child lies in a makeshift bed of 2 mismatched chairs. An outstretched left arm hangs over the pillow, signaling a certain precariousness of the moment. The doctor’s presence signals some hope that the child will recover.</p>",
+      "position_right": true,
+      "index": 3,
+      "desktop": "698 432 384 384",
+      "tablet": "578 452 619 619",
+      "mobile": "619 499 504 504"
+    },
+    {
+      "description": "<p>Not sitting tiredly despite a night vigil, the doctor is illuminated in a forward-leaning position, chin in his hand. His stare is not a casual gaze, but one that is intensely and diagnostically trained on the child.</p>",
+      "position_right": true,
+      "index": 4,
+      "desktop": "306 365 362 362",
+      "tablet": "337 398 363 363",
+      "mobile": "328 412 336 336"
+    },
+    {
+      "description": "<p>A fisherman’s net hardly visible in the rafters represents manual labor, presumably a means by which the father of the child supports his family. This labor is juxtaposed to the doctor’s intellectual and professional work, which apparently supersedes the power of manual labor and that of the child’s parents.</p>",
+      "position_right": false,
+      "index": 5,
+      "desktop": "306 22 330 330",
+      "tablet": "337 103 363 363",
+      "mobile": "328 68 336 336"
+    },
+    {
+      "description": "<p>The child’s parents recede into the background, reinforcing their helplessness to affect their child’s fate. A dawn light filtering through the window reveals the father comforting the mother, casting further uncertainty on their child’s immediate future.</p>",
+      "position_right": true,
+      "index": 6,
+      "desktop": "859 148 390 390",
+      "tablet": "754 178 538 538",
+      "mobile": "803 210 459 459"
+    },
+    {
+      "description": "<p>Despite the painting’s depiction, a doctor’s presence in a working-class home is more idealized than reality. During the Victorian era, such house calls were generally afforded to those with wealth and power.</p>",
+      "position_right": false,
+      "index": 7,
+      "desktop": "352 335 653 653",
+      "tablet": "216 145 942 942",
+      "mobile": "335 348 611 611"
+    },
+    {
+      "description": "<p>Prior paintings of the ill at home also never depicted a medical practitioner with a bottle of medicine, which was previously associated with only familial caregivers.<sup>4</sup></p>",
+      "position_right": false,
+      "index": 8,
+      "desktop": "-41 471 210 210",
+      "tablet": "10 479 185 185",
+      "mobile": "21 504 122 122"
+    },
+    {
+      "description": "<p>On the floor, 2 fragments of paper are probably the filled prescription for the medicine.<sup>5</sup> The torn and crumpled prescription suggests that the medicine has been dispensed, but its effect remains an open question.</p>",
+      "position_right": true,
+      "index": 9,
+      "desktop": "670 836 248 248",
+      "tablet": "566 837 337 337",
+      "mobile": "619 795 325 325"
+    }
+  ]
 }

--- a/styleguide/source/_patterns/03-organisms/vc-scroll-zoom/vc-scroll-zoom.json
+++ b/styleguide/source/_patterns/03-organisms/vc-scroll-zoom/vc-scroll-zoom.json
@@ -6,55 +6,68 @@
     "captions": [
       {
         "description": "<p>One of the most recognized paintings of Western medicine, Luke Fildes’ The Doctor was hailed as an ideal representation of caring when it was first exhibited at the Royal Academy of Art in 1891. Henry Tate wanted an English painting worthy of a new gallery in his name, but he left the subject matter of his commission to Fildes.</p>",
-        "position_right": false
+        "position_right": false,
+        "index": 0
       },
       {
         "description": "<p>As witness to a doctor’s care of his son who died of typhoid fever, Fildes wanted to “put on record the status of the doctor.”<sup>1</sup> Fildes’ surviving son wrote that his father “must have thought a great deal on the subject for…. it was the easiest and quickest painted of his big pictures.”</p>",
-        "position_right": false
+        "position_right": false,
+        "index": 1
       },
       {
         "description": "<p>Light has long symbolized hope and wisdom and a table lamp provides the primary illumination in this otherwise dimly lit scene. At first glance, the doctor and his young patient seem to be the only figures present.</p>",
-        "position_right": true
+        "position_right": true,
+        "index": 2
       },
       {
         "description": "<p>Nearly centered in the painting, the child lies in a makeshift bed of <sup>2</sup> mismatched chairs. An outstretched left arm hangs over the pillow, signaling a certain precariousness of the moment. The doctor’s presence signals some hope that the child will recover.</p>",
-        "position_right": false
+        "position_right": false,
+        "index": 3
       },
       {
         "description": "<p>Not sitting tiredly despite a night vigil, the doctor is illuminated in a forward-leaning position, chin in his hand. His stare is not a casual gaze, but one that is intensely and diagnostically trained on the child.</p>",
-        "position_right": true
+        "position_right": true,
+        "index": 4
       },
       {
         "description": "<p>A fisherman’s net hardly visible in the rafters represents manual labor, presumably a means by which the father of the child supports his family. This labor is juxtaposed to the doctor’s intellectual and professional work, which apparently supersedes the power of manual labor and that of the child’s parents.</p>",
-        "position_right": true
+        "position_right": true,
+        "index": 5
       },
       {
         "description": "<p>The child’s parents recede into the background, reinforcing their helplessness to affect their child’s fate. A dawn light filtering through the window reveals the father comforting the mother, casting further uncertainty on their child’s immediate future.</p>",
-        "position_right": false
+        "position_right": false,
+        "index": 6
       },
       {
         "description": "<p>Despite the painting’s depiction, a doctor’s presence in a working-class home is more idealized than reality. During the Victorian era, such house calls were generally afforded to those with wealth and power.</p>",
-        "position_right": false
+        "position_right": false,
+        "index": 7
       },
       {
         "description": "<p>Prior paintings of the ill at home also never depicted a medical practitioner with a bottle of medicine, which was previously associated with only familial caregivers.<sup>3</sup> The content of this bottle is unknown, but it wasn’t a typhoid vaccine, since none existed until 1896.<sup>4</sup></p>",
-        "position_right": true
+        "position_right": true,
+        "index": 8
       },
       {
         "description": "<p>On the floor, 2 fragments of paper are probably the filled prescription for the medicine.<sup>5</sup> The torn and crumpled prescription suggests that the medicine has been dispensed, but its effect remains an open question.</p>",
-        "position_right": false
+        "position_right": false,
+        "index": 9
       },
       {
         "description": "<p>It is notable that the stethoscope, thermometer, and other advances of medical science are nowhere to be seen. Instead, a cup and spoon are the instruments presumably used to deliver medicine to the sick child.<sup>6</sup> Fildes seemed more intent on focusing our attention on the art than the science of medicine.</p>",
-        "position_right": true
+        "position_right": true,
+        "index": 10
       },
       {
         "description": "<p>Despite its idealized representation of doctoring or likely because of it, The Doctor struck a resonant chord with the public and profession alike. An engraved print of the painting sold more than 1 million copies in the United States. ”A library of books written in your honour would not do what this picture has done and will do for the medical profession in making the hearts of our fellow men warm to us with confidence and affection,” wrote a physician critic in 1892.<sup>7</sup></p>",
-        "position_right": false
+        "position_right": false,
+        "index": 11
       },
       {
         "description": "<p>Given its popular and professional appeal, The Doctor has been employed over the years to depict the practice of medicine in highly public and sometimes contradictory ways.</p>",
-        "position_right": false
+        "position_right": false,
+        "index": 12
       }
     ]
   }

--- a/styleguide/source/_patterns/03-organisms/vc-scroll-zoom/vc-scroll-zoom.json
+++ b/styleguide/source/_patterns/03-organisms/vc-scroll-zoom/vc-scroll-zoom.json
@@ -5,17 +5,20 @@
     "image": "<img srcset='../../assets/images/vc/bg-hero-ethics--small.jpg  640w, ../../assets/images/vc/bg-hero-ethics--medium.jpg  1280w, ../../assets/images/vc/bg-hero-ethics--large.jpg 2560w' sizes='100vw' src='../../assets/images/vc/bg-hero-ethics--large.jpg' alt='Alt text'>",
     "captions": [
       {
-        "description": "<p>One of the most recognized paintings of Western medicine, Luke Fildes’ The Doctor was hailed as an ideal representation of caring when it was first exhibited at the Royal Academy of Art in 1891. Henry Tate wanted an English painting worthy of a new gallery in his name, but he left the subject matter of his commission to Fildes.</p>"
+        "description": "<p>One of the most recognized paintings of Western medicine, Luke Fildes’ The Doctor was hailed as an ideal representation of caring when it was first exhibited at the Royal Academy of Art in 1891. Henry Tate wanted an English painting worthy of a new gallery in his name, but he left the subject matter of his commission to Fildes.</p>",
+        "position_right": false
       },
       {
-        "description": "<p>As witness to a doctor’s care of his son who died of typhoid fever, Fildes wanted to “put on record the status of the doctor.”<sup>1</sup> Fildes’ surviving son wrote that his father “must have thought a great deal on the subject for…. it was the easiest and quickest painted of his big pictures.”</p>"
+        "description": "<p>As witness to a doctor’s care of his son who died of typhoid fever, Fildes wanted to “put on record the status of the doctor.”<sup>1</sup> Fildes’ surviving son wrote that his father “must have thought a great deal on the subject for…. it was the easiest and quickest painted of his big pictures.”</p>",
+        "position_right": false
       },
       {
         "description": "<p>Light has long symbolized hope and wisdom and a table lamp provides the primary illumination in this otherwise dimly lit scene. At first glance, the doctor and his young patient seem to be the only figures present.</p>",
         "position_right": true
       },
       {
-        "description": "<p>Nearly centered in the painting, the child lies in a makeshift bed of <sup>2</sup> mismatched chairs. An outstretched left arm hangs over the pillow, signaling a certain precariousness of the moment. The doctor’s presence signals some hope that the child will recover.</p>"
+        "description": "<p>Nearly centered in the painting, the child lies in a makeshift bed of <sup>2</sup> mismatched chairs. An outstretched left arm hangs over the pillow, signaling a certain precariousness of the moment. The doctor’s presence signals some hope that the child will recover.</p>",
+        "position_right": false
       },
       {
         "description": "<p>Not sitting tiredly despite a night vigil, the doctor is illuminated in a forward-leaning position, chin in his hand. His stare is not a casual gaze, but one that is intensely and diagnostically trained on the child.</p>",
@@ -26,27 +29,32 @@
         "position_right": true
       },
       {
-        "description": "<p>The child’s parents recede into the background, reinforcing their helplessness to affect their child’s fate. A dawn light filtering through the window reveals the father comforting the mother, casting further uncertainty on their child’s immediate future.</p>"
+        "description": "<p>The child’s parents recede into the background, reinforcing their helplessness to affect their child’s fate. A dawn light filtering through the window reveals the father comforting the mother, casting further uncertainty on their child’s immediate future.</p>",
+        "position_right": false
       },
       {
-        "description": "<p>Despite the painting’s depiction, a doctor’s presence in a working-class home is more idealized than reality. During the Victorian era, such house calls were generally afforded to those with wealth and power.</p>"
+        "description": "<p>Despite the painting’s depiction, a doctor’s presence in a working-class home is more idealized than reality. During the Victorian era, such house calls were generally afforded to those with wealth and power.</p>",
+        "position_right": false
       },
       {
         "description": "<p>Prior paintings of the ill at home also never depicted a medical practitioner with a bottle of medicine, which was previously associated with only familial caregivers.<sup>3</sup> The content of this bottle is unknown, but it wasn’t a typhoid vaccine, since none existed until 1896.<sup>4</sup></p>",
         "position_right": true
       },
       {
-        "description": "<p>On the floor, 2 fragments of paper are probably the filled prescription for the medicine.<sup>5</sup> The torn and crumpled prescription suggests that the medicine has been dispensed, but its effect remains an open question.</p>"
+        "description": "<p>On the floor, 2 fragments of paper are probably the filled prescription for the medicine.<sup>5</sup> The torn and crumpled prescription suggests that the medicine has been dispensed, but its effect remains an open question.</p>",
+        "position_right": false
       },
       {
         "description": "<p>It is notable that the stethoscope, thermometer, and other advances of medical science are nowhere to be seen. Instead, a cup and spoon are the instruments presumably used to deliver medicine to the sick child.<sup>6</sup> Fildes seemed more intent on focusing our attention on the art than the science of medicine.</p>",
         "position_right": true
       },
       {
-        "description": "<p>Despite its idealized representation of doctoring or likely because of it, The Doctor struck a resonant chord with the public and profession alike. An engraved print of the painting sold more than 1 million copies in the United States. ”A library of books written in your honour would not do what this picture has done and will do for the medical profession in making the hearts of our fellow men warm to us with confidence and affection,” wrote a physician critic in 1892.<sup>7</sup></p>"
+        "description": "<p>Despite its idealized representation of doctoring or likely because of it, The Doctor struck a resonant chord with the public and profession alike. An engraved print of the painting sold more than 1 million copies in the United States. ”A library of books written in your honour would not do what this picture has done and will do for the medical profession in making the hearts of our fellow men warm to us with confidence and affection,” wrote a physician critic in 1892.<sup>7</sup></p>",
+        "position_right": false
       },
       {
-        "description": "<p>Given its popular and professional appeal, The Doctor has been employed over the years to depict the practice of medicine in highly public and sometimes contradictory ways.</p>"
+        "description": "<p>Given its popular and professional appeal, The Doctor has been employed over the years to depict the practice of medicine in highly public and sometimes contradictory ways.</p>",
+        "position_right": false
       }
     ]
   }

--- a/styleguide/source/_patterns/03-organisms/vc-scroll-zoom/vc-scroll-zoom.twig
+++ b/styleguide/source/_patterns/03-organisms/vc-scroll-zoom/vc-scroll-zoom.twig
@@ -13,7 +13,7 @@
       >
         <svg viewBox="{{ startingcoords_desktop }}" x="100%" y="100%">
           <foreignObject style="overflow: visible; width: 100%; height: 100%">
-            <img src="{{ image }}" />
+            <img src="{{ image }}" class="svg-embedded-image" />
           </foreignObject>
         </svg>
       </div>

--- a/styleguide/source/_patterns/03-organisms/vc-scroll-zoom/vc-scroll-zoom.twig
+++ b/styleguide/source/_patterns/03-organisms/vc-scroll-zoom/vc-scroll-zoom.twig
@@ -1,15 +1,35 @@
 <div class="vc-scroll-zoom">
   <div class="vc-scroll-zoom__image-container">
     <div class="vc-scroll-zoom__image-blur">
-      {{ scroll_zoom.image|raw }}
+      <img src="{{ image }}" />
     </div>
     <div class="vc-scroll-zoom__image">
-      {{ scroll_zoom.image|raw }}
+      <div class="image-wrapper loading first static-display"
+           data-section="static"
+           data-coordinates-desktop="{{ startingcoords_desktop }}"
+           data-coordinates-tablet="{{ startingcoords_tablet }}"
+           data-coordinates-mobile="{{ startingcoords_mobile }}"
+           data-anchor="part-0"
+      >
+        <svg viewBox="{{ startingcoords_desktop }}" x="100%" y="100%">
+          <foreignObject style="overflow: visible; width: 100%; height: 100%">
+            <img src="{{ image }}" />
+          </foreignObject>
+        </svg>
+      </div>
     </div>
   </div>
   <div class="vc-scroll-zoom__captions vc-container">
-    {% for caption in scroll_zoom.captions %}
-      <div class="vc-scroll-zoom__caption {% if caption.position_right %}vc-scroll-zoom__caption--right{% endif %}">
+    {% for caption in captions %}
+      <div class="vc-scroll-zoom__caption
+        {% if caption.position_right %}vc-scroll-zoom__caption--right{% endif %}
+        part-{{ caption.index + 1 }} section"
+           data-section="dynamic"
+           data-coordinates-desktop="{{ caption.desktop }}"
+           data-coordinates-tablet="{{ caption.tablet }}"
+           data-coordinates-mobile="{{ caption.mobile }}"
+           data-anchor="part-{{ caption.index + 1 }}"
+      >
         <div class="vc-scroll-zoom__caption-desc vc-ethics-pattern">
           {{ caption.description|raw }}
         </div>

--- a/styleguide/source/_patterns/03-organisms/vc-scroll-zoom/vc-scroll-zoom.twig
+++ b/styleguide/source/_patterns/03-organisms/vc-scroll-zoom/vc-scroll-zoom.twig
@@ -1,8 +1,5 @@
 <div class="vc-scroll-zoom">
   <div class="vc-scroll-zoom__image-container">
-    <div class="vc-scroll-zoom__image-blur">
-      <img src="{{ image }}" />
-    </div>
     <div class="vc-scroll-zoom__image">
       <div class="image-wrapper loading first static-display"
            data-section="static"

--- a/styleguide/source/_patterns/05-pages/vc-ethics-dark.json
+++ b/styleguide/source/_patterns/05-pages/vc-ethics-dark.json
@@ -15,32 +15,94 @@
   "abstract": {
     "content": "<p class='lede'>One of the most recognized paintings of Western medicine, Luke Fildes’ The Doctor aimed to represent a caring physician in a humble setting during an era when people living with poverty rarely had access to health care and nearly all physicians were White men. The Doctor challenges us to think about what good doctoring is.</p>"
   },
-  "scroll_zoom_1": {
-    "image": "<img srcset='../../assets/images/vc/bg-hero-ethics--small.jpg  640w, ../../assets/images/vc/bg-hero-ethics--medium.jpg  1280w, ../../assets/images/vc/bg-hero-ethics--large.jpg 2560w' sizes='100vw' src='../../assets/images/vc/bg-hero-ethics--large.jpg' alt='Alt text'>",
+  "scroll_zoom": {
+    "htmlClass": "vc-ethics",
+    "theme_mode": "dark",
+    "startingcoords_desktop": "330 183 864 864",
+    "startingcoords_mobile": "365 254 728 728",
+    "startingcoords_tablet": "193 114 1062 1062",
+    "image": "../../assets/images/vc/bg-hero-ethics--large.jpg",
+    "alt_text": "Luke Fildes’ painting 'The Doctor'",
     "captions": [
       {
-        "description": "<p>One of the most recognized paintings of Western medicine, Luke Fildes’ The Doctor was hailed as an ideal representation of caring when it was first exhibited at the Royal Academy of Art in 1891. Henry Tate wanted an English painting worthy of a new gallery in his name, but he left the subject matter of his commission to Fildes.</p>"
+        "description": "<p>One of the most recognized paintings of Western medicine, Luke Fildes’ The Doctor was hailed as an ideal representation of caring when it was first exhibited at the Royal Academy of Art in 1891. Henry Tate wanted an English painting worthy of a new gallery in his name, but he left the subject matter of his commission to Fildes.</p>",
+        "position_right": false,
+        "index": 0,
+        "desktop": "",
+        "tablet": "",
+        "mobile": ""
       },
       {
-        "description": "<p>As witness to a doctor’s care of his son who died of typhoid fever, Fildes wanted to “put on record the status of the doctor.”<sup>1</sup> Fildes’ surviving son wrote that his father “must have thought a great deal on the subject for…. it was the easiest and quickest painted of his big pictures.”</p>"
+        "description": "<p>As witness to a doctor’s care of his son who died of typhoid fever, Fildes wanted to put on record the status of the doctor.</p>",
+        "position_right": true,
+        "index": 1,
+        "desktop": "563 276 305 305",
+        "tablet": "341 240 743 743",
+        "mobile": "438 364 549 549"
       },
       {
         "description": "<p>Light has long symbolized hope and wisdom and a table lamp provides the primary illumination in this otherwise dimly lit scene. At first glance, the doctor and his young patient seem to be the only figures present.</p>",
-        "position_right": true
+        "position_right": false,
+        "index": 2,
+        "desktop": "51 320 278 278",
+        "tablet": "101 341 186 186",
+        "mobile": "81 364 219 219"
       },
       {
-        "description": "<p>Nearly centered in the painting, the child lies in a makeshift bed of <sup>2</sup> mismatched chairs. An outstretched left arm hangs over the pillow, signaling a certain precariousness of the moment. The doctor’s presence signals some hope that the child will recover.</p>"
+        "description": "<p>Nearly centered in the painting, the child lies in a makeshift bed of 2 mismatched chairs. An outstretched left arm hangs over the pillow, signaling a certain precariousness of the moment. The doctor’s presence signals some hope that the child will recover.</p>",
+        "position_right": true,
+        "index": 3,
+        "desktop": "698 432 384 384",
+        "tablet": "578 452 619 619",
+        "mobile": "619 499 504 504"
       },
       {
         "description": "<p>Not sitting tiredly despite a night vigil, the doctor is illuminated in a forward-leaning position, chin in his hand. His stare is not a casual gaze, but one that is intensely and diagnostically trained on the child.</p>",
-        "position_right": true
+        "position_right": true,
+        "index": 4,
+        "desktop": "306 365 362 362",
+        "tablet": "337 398 363 363",
+        "mobile": "328 412 336 336"
       },
       {
         "description": "<p>A fisherman’s net hardly visible in the rafters represents manual labor, presumably a means by which the father of the child supports his family. This labor is juxtaposed to the doctor’s intellectual and professional work, which apparently supersedes the power of manual labor and that of the child’s parents.</p>",
-        "position_right": true
+        "position_right": false,
+        "index": 5,
+        "desktop": "306 22 330 330",
+        "tablet": "337 103 363 363",
+        "mobile": "328 68 336 336"
       },
       {
-        "description": "<p>The child’s parents recede into the background, reinforcing their helplessness to affect their child’s fate. A dawn light filtering through the window reveals the father comforting the mother, casting further uncertainty on their child’s immediate future.</p>"
+        "description": "<p>The child’s parents recede into the background, reinforcing their helplessness to affect their child’s fate. A dawn light filtering through the window reveals the father comforting the mother, casting further uncertainty on their child’s immediate future.</p>",
+        "position_right": true,
+        "index": 6,
+        "desktop": "859 148 390 390",
+        "tablet": "754 178 538 538",
+        "mobile": "803 210 459 459"
+      },
+      {
+        "description": "<p>Despite the painting’s depiction, a doctor’s presence in a working-class home is more idealized than reality. During the Victorian era, such house calls were generally afforded to those with wealth and power.</p>",
+        "position_right": false,
+        "index": 7,
+        "desktop": "352 335 653 653",
+        "tablet": "216 145 942 942",
+        "mobile": "335 348 611 611"
+      },
+      {
+        "description": "<p>Prior paintings of the ill at home also never depicted a medical practitioner with a bottle of medicine, which was previously associated with only familial caregivers.<sup>4</sup></p>",
+        "position_right": false,
+        "index": 8,
+        "desktop": "-41 471 210 210",
+        "tablet": "10 479 185 185",
+        "mobile": "21 504 122 122"
+      },
+      {
+        "description": "<p>On the floor, 2 fragments of paper are probably the filled prescription for the medicine.<sup>5</sup> The torn and crumpled prescription suggests that the medicine has been dispensed, but its effect remains an open question.</p>",
+        "position_right": true,
+        "index": 9,
+        "desktop": "670 836 248 248",
+        "tablet": "566 837 337 337",
+        "mobile": "619 795 325 325"
       }
     ]
   },
@@ -71,31 +133,6 @@
       "question": "How does this cello suite make you feel?",
       "total": 1
     }
-  },
-  "scroll_zoom_2": {
-    "image": "<img srcset='../../assets/images/vc/bg-hero-ethics--small.jpg  640w, ../../assets/images/vc/bg-hero-ethics--medium.jpg  1280w, ../../assets/images/vc/bg-hero-ethics--large.jpg 2560w' sizes='100vw' src='../../assets/images/vc/bg-hero-ethics--large.jpg' alt='Alt text'>",
-    "captions": [
-      {
-        "description": "<p>Despite the painting’s depiction, a doctor’s presence in a working-class home is more idealized than reality. During the Victorian era, such house calls were generally afforded to those with wealth and power.</p>"
-      },
-      {
-        "description": "<p>Prior paintings of the ill at home also never depicted a medical practitioner with a bottle of medicine, which was previously associated with only familial caregivers.<sup>3</sup> The content of this bottle is unknown, but it wasn’t a typhoid vaccine, since none existed until 1896.<sup>4</sup></p>",
-        "position_right": true
-      },
-      {
-        "description": "<p>On the floor, 2 fragments of paper are probably the filled prescription for the medicine.<sup>5</sup> The torn and crumpled prescription suggests that the medicine has been dispensed, but its effect remains an open question.</p>"
-      },
-      {
-        "description": "<p>It is notable that the stethoscope, thermometer, and other advances of medical science are nowhere to be seen. Instead, a cup and spoon are the instruments presumably used to deliver medicine to the sick child.<sup>6</sup> Fildes seemed more intent on focusing our attention on the art than the science of medicine.</p>",
-        "position_right": true
-      },
-      {
-        "description": "<p>Despite its idealized representation of doctoring or likely because of it, The Doctor struck a resonant chord with the public and profession alike. An engraved print of the painting sold more than 1 million copies in the United States. ”A library of books written in your honour would not do what this picture has done and will do for the medical profession in making the hearts of our fellow men warm to us with confidence and affection,” wrote a physician critic in 1892.<sup>7</sup></p>"
-      },
-      {
-        "description": "<p>Given its popular and professional appeal, The Doctor has been employed over the years to depict the practice of medicine in highly public and sometimes contradictory ways.</p>"
-      }
-    ]
   },
   "featured_media_2": {
     "image": "<img src='../../assets/images/vc/img-ethics-1-figure2.jpg' alt='Alt text'>",

--- a/styleguide/source/_patterns/05-pages/vc-ethics-dark.json
+++ b/styleguide/source/_patterns/05-pages/vc-ethics-dark.json
@@ -100,8 +100,8 @@
         "description": "<p>On the floor, 2 fragments of paper are probably the filled prescription for the medicine.<sup>5</sup> The torn and crumpled prescription suggests that the medicine has been dispensed, but its effect remains an open question.</p>",
         "position_right": true,
         "index": 9,
-        "desktop": "670 836 248 248",
-        "tablet": "566 837 337 337",
+        "desktop": "352 335 453 453",
+        "tablet": "-41 471 942 942",
         "mobile": "619 795 325 325"
       }
     ]

--- a/styleguide/source/_patterns/05-pages/vc-ethics-dark.twig
+++ b/styleguide/source/_patterns/05-pages/vc-ethics-dark.twig
@@ -21,8 +21,8 @@
     layout_heading: null
   } %}
     {% block layout_bottom %}
-      {% set scroll_zoom = scroll_zoom_1 %}
-      {% include "@organisms/vc-scroll-zoom/vc-scroll-zoom.twig" %}
+      {% set scroll_zoom = scroll_zoom %}
+      {% include "@organisms/vc-scroll-zoom/vc-scroll-zoom.twig" with scroll_zoom %}
     {% endblock %}
   {% endembed %}
 
@@ -56,16 +56,6 @@
     {% block layout_bottom %}
       {% set reaction = featured_audio.reaction %}
       {% include "@organisms/vc-featured-audio/vc-featured-audio.twig" %}
-    {% endblock %}
-  {% endembed %}
-
-  {% embed "@base/vc-layout-paragraphs/vc-layout-paragraphs.twig" with {
-    layout_fullwidth: true,
-    layout_heading: null
-  } %}
-    {% block layout_bottom %}
-      {% set scroll_zoom = scroll_zoom_2 %}
-      {% include "@organisms/vc-scroll-zoom/vc-scroll-zoom.twig" %}
     {% endblock %}
   {% endembed %}
 

--- a/styleguide/source/_patterns/05-pages/vc-ethics-light.json
+++ b/styleguide/source/_patterns/05-pages/vc-ethics-light.json
@@ -101,7 +101,7 @@
         "description": "<p>On the floor, 2 fragments of paper are probably the filled prescription for the medicine.<sup>5</sup> The torn and crumpled prescription suggests that the medicine has been dispensed, but its effect remains an open question.</p>",
         "position_right": true,
         "index": 9,
-        "desktop": "670 836 248 248",
+        "desktop": "352 335 453 453",
         "tablet": "566 837 337 337",
         "mobile": "619 795 325 325"
       }

--- a/styleguide/source/_patterns/05-pages/vc-ethics-light.json
+++ b/styleguide/source/_patterns/05-pages/vc-ethics-light.json
@@ -16,21 +16,94 @@
   "abstract": {
     "content": "<p class='lede'>Eleven million undocumented immigrants in the United States, including children, face barriers to health. By practicing 4 elements of <a href='#'>sanctuary health care</a>, clinicians and organizations can help.</p>"
   },
-  "scroll_zoom_1": {
-    "image": "<img srcset='../../assets/images/vc/bg-hero-ethics-light--small.jpg  640w, ../../assets/images/vc/bg-hero-ethics-light--medium.jpg  1280w, ../../assets/images/vc/bg-hero-ethics-light--large.jpg 2560w' sizes='100vw' src='../../assets/images/vc/bg-hero-ethic-light--large.jpg' alt='Alt text'>",
+  "scroll_zoom": {
+    "htmlClass": "vc-ethics",
+    "theme_mode": "light",
+    "startingcoords_desktop": "330 183 864 864",
+    "startingcoords_mobile": "365 254 728 728",
+    "startingcoords_tablet": "193 114 1062 1062",
+    "image": "../../assets/images/vc/bg-hero-ethics--large.jpg",
+    "alt_text": "Luke Fildes’ painting 'The Doctor'",
     "captions": [
       {
-        "description": "<p>Example caption lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus vehicula orci et purus ornare finibus. Suspendisse eleifend sagittis lacus at molestie. Mauris maximus mi diam, viverra malesuada elit placerat sit amet.</p>"
+        "description": "<p>One of the most recognized paintings of Western medicine, Luke Fildes’ The Doctor was hailed as an ideal representation of caring when it was first exhibited at the Royal Academy of Art in 1891. Henry Tate wanted an English painting worthy of a new gallery in his name, but he left the subject matter of his commission to Fildes.</p>",
+        "position_right": false,
+        "index": 0,
+        "desktop": "",
+        "tablet": "",
+        "mobile": ""
       },
       {
-        "description": "<p>Example caption lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus vehicula orci et purus ornare finibus. Suspendisse eleifend sagittis lacus at molestie. Mauris maximus mi diam, viverra malesuada elit placerat sit amet.</p>"
+        "description": "<p>As witness to a doctor’s care of his son who died of typhoid fever, Fildes wanted to put on record the status of the doctor.</p>",
+        "position_right": true,
+        "index": 1,
+        "desktop": "563 276 305 305",
+        "tablet": "341 240 743 743",
+        "mobile": "438 364 549 549"
       },
       {
-        "description": "<p>Example caption lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus vehicula orci et purus ornare finibus. Suspendisse eleifend sagittis lacus at molestie. Mauris maximus mi diam, viverra malesuada elit placerat sit amet.</p>",
-        "position_right": true
+        "description": "<p>Light has long symbolized hope and wisdom and a table lamp provides the primary illumination in this otherwise dimly lit scene. At first glance, the doctor and his young patient seem to be the only figures present.</p>",
+        "position_right": false,
+        "index": 2,
+        "desktop": "51 320 278 278",
+        "tablet": "101 341 186 186",
+        "mobile": "81 364 219 219"
       },
       {
-        "description": "<p>Example caption lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus vehicula orci et purus ornare finibus. Suspendisse eleifend sagittis lacus at molestie. Mauris maximus mi diam, viverra malesuada elit placerat sit amet.</p>"
+        "description": "<p>Nearly centered in the painting, the child lies in a makeshift bed of 2 mismatched chairs. An outstretched left arm hangs over the pillow, signaling a certain precariousness of the moment. The doctor’s presence signals some hope that the child will recover.</p>",
+        "position_right": true,
+        "index": 3,
+        "desktop": "698 432 384 384",
+        "tablet": "578 452 619 619",
+        "mobile": "619 499 504 504"
+      },
+      {
+        "description": "<p>Not sitting tiredly despite a night vigil, the doctor is illuminated in a forward-leaning position, chin in his hand. His stare is not a casual gaze, but one that is intensely and diagnostically trained on the child.</p>",
+        "position_right": true,
+        "index": 4,
+        "desktop": "306 365 362 362",
+        "tablet": "337 398 363 363",
+        "mobile": "328 412 336 336"
+      },
+      {
+        "description": "<p>A fisherman’s net hardly visible in the rafters represents manual labor, presumably a means by which the father of the child supports his family. This labor is juxtaposed to the doctor’s intellectual and professional work, which apparently supersedes the power of manual labor and that of the child’s parents.</p>",
+        "position_right": false,
+        "index": 5,
+        "desktop": "306 22 330 330",
+        "tablet": "337 103 363 363",
+        "mobile": "328 68 336 336"
+      },
+      {
+        "description": "<p>The child’s parents recede into the background, reinforcing their helplessness to affect their child’s fate. A dawn light filtering through the window reveals the father comforting the mother, casting further uncertainty on their child’s immediate future.</p>",
+        "position_right": true,
+        "index": 6,
+        "desktop": "859 148 390 390",
+        "tablet": "754 178 538 538",
+        "mobile": "803 210 459 459"
+      },
+      {
+        "description": "<p>Despite the painting’s depiction, a doctor’s presence in a working-class home is more idealized than reality. During the Victorian era, such house calls were generally afforded to those with wealth and power.</p>",
+        "position_right": false,
+        "index": 7,
+        "desktop": "352 335 653 653",
+        "tablet": "216 145 942 942",
+        "mobile": "335 348 611 611"
+      },
+      {
+        "description": "<p>Prior paintings of the ill at home also never depicted a medical practitioner with a bottle of medicine, which was previously associated with only familial caregivers.<sup>4</sup></p>",
+        "position_right": false,
+        "index": 8,
+        "desktop": "-41 471 210 210",
+        "tablet": "10 479 185 185",
+        "mobile": "21 504 122 122"
+      },
+      {
+        "description": "<p>On the floor, 2 fragments of paper are probably the filled prescription for the medicine.<sup>5</sup> The torn and crumpled prescription suggests that the medicine has been dispensed, but its effect remains an open question.</p>",
+        "position_right": true,
+        "index": 9,
+        "desktop": "670 836 248 248",
+        "tablet": "566 837 337 337",
+        "mobile": "619 795 325 325"
       }
     ]
   },

--- a/styleguide/source/_patterns/05-pages/vc-ethics-light.twig
+++ b/styleguide/source/_patterns/05-pages/vc-ethics-light.twig
@@ -21,8 +21,8 @@
     layout_heading: null
   } %}
     {% block layout_bottom %}
-      {% set scroll_zoom = scroll_zoom_1 %}
-      {% include "@organisms/vc-scroll-zoom/vc-scroll-zoom.twig" %}
+      {% set scroll_zoom = scroll_zoom %}
+      {% include "@organisms/vc-scroll-zoom/vc-scroll-zoom.twig" with scroll_zoom %}
     {% endblock %}
   {% endembed %}
 

--- a/styleguide/source/assets/js/vc-scroll-zoom.js
+++ b/styleguide/source/assets/js/vc-scroll-zoom.js
@@ -12,10 +12,105 @@
   Drupal.behaviors.vc_scroll_zoom = {
     attach: function (context, settings) {
 
-      // Find all inViewCaptions classes
-      const inViewCaptions = document.querySelectorAll('.vc-scroll-zoom__captions');
+      /**
+       * Set the svg display, which controls image zoom based on caption.
+       */
 
-      // Find the dimensions of inViewport
+      const svg = $('.image-wrapper svg');
+      let viewBox = svg.attr('viewBox');
+      let anchorList = [];
+      let desktopCoordList = [];
+      let tabletCoordList = [];
+      let mobileCoordList = [];
+      let viewboxCoords;
+      let breakpoint;
+
+      // Get caption data.
+      function loadArrays() {
+        // Add each anchor to an array
+        $('div[data-anchor]').each(function(idx, el){
+          anchorList.push($(this).attr('data-anchor'));
+        });
+        // Add each coordinate to an array
+        $('div[data-coordinates-desktop]').each(function(idx, el){
+          desktopCoordList.push($(this).attr('data-coordinates-desktop'));
+          tabletCoordList.push($(this).attr('data-coordinates-tablet'));
+          mobileCoordList.push($(this).attr('data-coordinates-mobile'));
+        });
+      }
+
+      // Portable svg update function
+      function updateSvg(coords) {
+        svg.attr({
+          viewBox: coords,
+        });
+      }
+
+      // Set active breakpoint on resize.
+      function breakpointCheck(width, height) {
+        if (width < 900) {
+          breakpoint = 'mobile';
+        }
+        if (width > 900 && width < 1200) {
+          breakpoint = 'tablet';
+        }
+        if (width > 1200) {
+          breakpoint = 'desktop';
+        }
+      }
+
+      // Initialize the initial viewbox coordinates based on breakpoint.
+      function setInitialCoords() {
+        let height = $(window).height();
+        let width = $(window).width();
+
+        //  Run the breakpoint check
+        breakpointCheck(width, height);
+
+        //  Set starting coords based on first slide.
+        let coords = $('.static-display').attr('data-coordinates-' + breakpoint);
+
+        //  set coords
+        updateSvg(coords);
+      }
+
+      // Set the proper coordinates based on breakpoint and available values.
+      function getCoords(index) {
+        // Set the defaults.
+        viewboxCoords = '50 65 530 530';
+
+        //  if desktop
+        if (breakpoint === 'desktop') {
+          if (desktopCoordList[index]) {
+            viewboxCoords = desktopCoordList[index];
+          }
+        }
+        if (breakpoint === 'tablet') {
+          if (tabletCoordList[index]) {
+            viewboxCoords = tabletCoordList[index];
+          }
+        }
+        if (breakpoint === 'mobile') {
+          if (mobileCoordList[index]) {
+            viewboxCoords = mobileCoordList[index];
+          }
+        }
+
+        return viewboxCoords;
+      }
+
+      /**
+       * Set the scroll behaviors.
+       */
+
+        // Find all captionsBox classes. These are captioned images.
+      const captionsBox = document.querySelectorAll('.vc-scroll-zoom__captions');
+
+      // Find all unique captions inside the image.
+      // @todo This only allows one per instance per page.
+      const captionsList = document.querySelectorAll('.vc-scroll-zoom__caption');
+
+      // Find the dimensions of captionsBox
       const inViewport = function (e) {
         const distance = e.getBoundingClientRect();
         return (
@@ -27,18 +122,30 @@
 
       // Set inView
       function isInView() {
-        for (let i = 0; i < inViewCaptions.length; i++) {
-          if (inViewport(inViewCaptions[i])) {
-            // If in view
-            inViewCaptions[i].previousElementSibling.classList.add('is-sticky');
+        for (let i = 0; i < captionsBox.length; i++) {
+          if (inViewport(captionsBox[i])) {
+            // If in view set the bounding image box to sticky.
+            captionsBox[i].previousElementSibling.classList.add('is-sticky');
+
+            // Now determine which caption we are looking at.
+            for (let j = 0; j < captionsList.length; j++) {
+              if (inViewport(captionsList[j])) {
+                // Get the SVG render options, offset by 1 to account for the initial image.
+                coords = getCoords(j + 1);
+                updateSvg(coords);
+              }
+            }
           } else {
-            inViewCaptions[i].previousElementSibling.classList.remove('is-sticky');
+            captionsBox[i].previousElementSibling.classList.remove('is-sticky');
+            // The 0th element is the default image.
+            coords = getCoords(0);
+            updateSvg(coords);
           }
         }
       }
 
-      // If has inViewCaptions, run throttled inViewport
-      if (inViewCaptions) {
+      // If has captionsBox, run throttled inViewport
+      if (captionsBox) {
         // Set throttle variables
         let lastScrollPosition = 0;
         let throttle = false;
@@ -56,6 +163,12 @@
           throttle = true;
         }, false);
       }
+
+      // Load the default image and data.
+      $(document).ready(function() {
+        loadArrays();
+        setInitialCoords();
+      });
     }
   };
 })(jQuery, Drupal);

--- a/styleguide/source/assets/scss/03-organisms/_vc-scroll-zoom.scss
+++ b/styleguide/source/assets/scss/03-organisms/_vc-scroll-zoom.scss
@@ -39,8 +39,6 @@
 
   img {
     object-fit: cover;
-    width: 100%;
-    height: 100%;
   }
 }
 


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

**Jira Ticket**

- https://palantir.atlassian.net/browse/JOE-212


## Description

Updates the vc-scoll-zoom component to:
* Use SVG to render the image so it can be panned / zoomed based coordinates set by editors
* Allow for image zoom when captions scroll into view (in the JS layer)

## To Test

- [ ] Checkout this branch and build the styleguide
- [ ] Load the page ?p=pages-vc-ethics-dark or the component ?p=organisms-vc-scroll-zoom
- [ ] Initial image load should be beneath the Abstract element
- [ ] When a caption comes into view, the background image should shift
- [ ] That shift should be appropriate to desktop (>1200 px), tablet (>900 <1200 px), and mobile (< 900 px) sizes. 


## Remaining Tasks

* Remove the additional display of the component from the page template
* Determine how the current code leverages SVG positioning -- the coordinates used here were taken from a node on the live site.
* Improve the zoom effect
* Ensure that forward / backward scroll places the correct caption view


## Additional Notes

* See https://github.com/AmericanMedicalAssociation/code-of-ethics/pull/216 which replicates this work inside Drupal
