### PR TITLE
JOE-194: Featured media figure text size

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_vc-featured-media.scss
+++ b/styleguide/source/assets/scss/03-organisms/_vc-featured-media.scss
@@ -34,7 +34,11 @@
 
 .vc-featured-media__caption {
   @include type($font-sans-serif, 0.9em, $font-weight-medium, 1.1);
-  padding-block: 0 1rem;
+  padding-block: 0 1rem; 
+
+  @include breakpoint($bp-med) {
+    @include type($font-sans-serif, 1em, $font-weight-medium, 1.1);
+  }
 }
 
 .vc-featured-media__copyright,

--- a/styleguide/source/assets/scss/03-organisms/_vc-slide-rule.scss
+++ b/styleguide/source/assets/scss/03-organisms/_vc-slide-rule.scss
@@ -158,6 +158,10 @@ $initial-reveal: 50%;
   @include type($font-sans-serif, 0.9em, $font-weight-medium, 1.1);
   padding-block: 0 1rem;
 
+  @include breakpoint($bp-med) {
+    @include type($font-sans-serif, 1em, $font-weight-medium, 1.1);
+  }
+
   .layout--onecol-fullwidth & {
     padding-inline: 1.25rem;
 


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

Please do not submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**

- N/A

**Jira Ticket**

- [EJOE-194: Featured media figure text size](https://palantir.atlassian.net/browse/JOE-194)


## Description

Remove the `font-size: 0.9rem` from figure text for this. To be clear, this would be all figure text across all components that use it, for all content types. The client has confirmed that this is preferred. [See ticket for screenshots and more details](https://palantir.atlassian.net/browse/JOE-194).

Note: I did keep the `font-size: 0.9rem` at mobile. When reviewing the figure text at all viewports, `1rem` felt a little big to me.

## To Test

- [x] Navigate to the [Featured Media](http://localhost:3000/?p=organisms-vc-featured-media) (image and video) components and inspect the "Figure" copy and ensure the `font-size` has been set to `1rem` which is the default font size.
- [x] Navigate to the [Slide Rule component](http://localhost:3000/?p=organisms-vc-slide-rule) and inspect the "Figure" copy and ensure the `font-size` has been set to `1rem` which is the default font size.
- [x] Review the component at all viewports and ensure the figure text looks sized appropriately.

## Visual Regressions

N/A


## Relevant Screenshots/GIFs

<img width="887" alt="Screenshot 2023-12-08 at 8 00 52 AM" src="https://github.com/AmericanMedicalAssociation/joe-style-guide/assets/362529/04139f41-c626-4356-ad4f-a5d47799ee06">


## Remaining Tasks

N/A

## Additional Notes

N/A
