### PR TITLE
JOE-186: Ethics close up heading alignment

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_vc-hero-ethics.scss
+++ b/styleguide/source/assets/scss/03-organisms/_vc-hero-ethics.scss
@@ -73,10 +73,15 @@
 
 .vc-hero-ethics__shape {
   @include breakpoint($bp-med) {
-    width: 600px;
+    width: 560px;
     height: 600px;
     float: left;
-    shape-outside: polygon(0% 100%, 0% 0%, 100% 100%);
+    shape-outside: polygon(16% 0px, 16% 22%, 100% 100%, 0px 100%, 0px 0px);
+  }
+
+  @include breakpoint($bp-large) {
+    width: 600px;
+    shape-outside: polygon(25% 0px, 25% 25%, 100% 100%, 0px 100%, 0px 0px);
   }
 }
 


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

Please do not submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**

- N/A

**Jira Ticket**

- [JOE-186: Ethics close up heading alignment](https://palantir.atlassian.net/browse/JOE-186)


## Description

The client would like the first line of text to be left-aligned with the node title for Ethics Close Up. [See ticket for screenshots and more details](https://palantir.atlassian.net/browse/JOE-186).


## To Test

- [x] Navigate to the [Ethics Close Up page](http://localhost:3000/?p=pages-vc-ethics-dark) and verify the first line of text aligns with the node title.
- [x] Verify the hero text alignment looks good at all viewports.

## Visual Regressions

N/A

## Relevant Screenshots/GIFs

<img width="1296" alt="Screenshot 2023-12-08 at 8 38 47 AM" src="https://github.com/AmericanMedicalAssociation/joe-style-guide/assets/362529/2b3cfdac-712c-4a2e-bb25-a6c9188364be">

## Remaining Tasks

N/A

## Additional Notes

N/A
