### PR TITLE
JOE-209: Remove hero carousel hover

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_vc-hero-gallery.scss
+++ b/styleguide/source/assets/scss/03-organisms/_vc-hero-gallery.scss
@@ -65,17 +65,6 @@
 
   a.vc-hero-gallery__anchor {
     text-decoration: none;
-
-    img {
-      max-width: 450px;
-      transition: all 0.3s ease;
-    }
-
-    &:hover {
-      img {
-        box-shadow: 0 0 0 6px var(--c-link);
-      }
-    }
   }
 
   .vc-hero-gallery__anchor-label {

--- a/styleguide/source/assets/scss/03-organisms/_vc-hero-gallery.scss
+++ b/styleguide/source/assets/scss/03-organisms/_vc-hero-gallery.scss
@@ -66,16 +66,6 @@
 
   a.vc-hero-gallery__anchor {
     text-decoration: none;
-
-    img {
-      transition: all 0.3s ease;
-    }
-
-    &:hover {
-      img {
-        box-shadow: 0 0 0 6px var(--c-link);
-      }
-    }
   }
 
   .vc-hero-gallery__anchor-label {


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

Please do not submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**

- N/A

**Jira Ticket**

- [JOE-209: Remove hero carousel hover](https://palantir.atlassian.net/browse/JOE-209)


## Description

On the Gallery Exhibition CT, there’s a black border on hover. We should remove/disable this. (i.e. match the hover effect on the Horizontal Gallery)

## To Test

- [x] Navigate to the [Gallery page](http://localhost:3000/?p=organisms-vc-hero-gallery) and ensure there is no border when you hover over each "Gallery Exhibition" item.

## Visual Regressions

N/A

## Relevant Screenshots/GIFs

![gallery-hover](https://github.com/AmericanMedicalAssociation/joe-style-guide/assets/362529/90fd33bd-3c3e-4f39-9a6b-15df4c6450df)

## Remaining Tasks

N/A

## Additional Notes

N/A