### PR TITLE
JOE-199: Carousel under hero height

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_vc-hero-gallery.scss
+++ b/styleguide/source/assets/scss/03-organisms/_vc-hero-gallery.scss
@@ -67,6 +67,7 @@
     text-decoration: none;
 
     img {
+      max-width: 450px;
       transition: all 0.3s ease;
     }
 
@@ -129,6 +130,10 @@
   align-items: center;
   gap: 1rem;
   padding-inline: 1rem;
+
+  @include breakpoint($bp-med) {
+    top: -2rem;
+  }
 }
 
 .vc-hero-gallery__nav-label {


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

Please do not submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**

- N/A

**Jira Ticket**

- [JOE-199: Carousel under hero height](https://issues.ama-assn.org/browse/EWL-XXXX)

## Description

It would be nice to be able to scroll through the carousel using the arrow functionality and still be able to see the entire artwork without the image being cut off at the top.

## To Test

- [x] Navigate to the Gallery page and resize your browser to “Laptop - Large” in the Responsive Browser Emulator.
- [x] Verify that you can access the top carousel navigation while also viewing the images above.

## Visual Regressions

N/A

## Relevant Screenshots/GIFs

N/A

## Remaining Tasks

N/A


## Additional Notes

N/A
