### PR TITLE
JOE-185: Gallery figure text should be closer to carousel

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_vc-horizontal-gallery.scss
+++ b/styleguide/source/assets/scss/03-organisms/_vc-horizontal-gallery.scss
@@ -3,6 +3,12 @@
     margin-block-start: 0;
   }
 
+  .vc-horizontal-gallery__items {
+    .slick-track {
+      padding-block-start: 0;
+    }
+  }
+
   .vc-modal__controls {
     .slick-arrow {
       display: flex;


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

Please do not submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**

- N/A

**Jira Ticket**

- [JOE-185: Gallery figure text should be closer to carousel](https://palantir.atlassian.net/browse/JOE-185)


## Description

Explain the technical implementation of the work done.


## To Test

- [x] Navigate to the [Horizontal gallery](http://localhost:3000/?p=pages-vc-art-text-left-full) component and verify the top copy is closer to the carousel.

## Visual Regressions

N/A


## Relevant Screenshots/GIFs

<img width="1501" alt="Screenshot 2023-12-08 at 2 24 04 PM" src="https://github.com/AmericanMedicalAssociation/joe-style-guide/assets/362529/43dc523e-c9b1-41a5-af07-8604c7d7fe82">



## Remaining Tasks

N/A

## Additional Notes

N/A
