### PR TITLE
JOE-181: ALL - Link color applied to admin toolbar

### DIFF
--- a/styleguide/source/assets/scss/00-base/_typography.scss
+++ b/styleguide/source/assets/scss/00-base/_typography.scss
@@ -123,7 +123,7 @@ sup {
 }
 
 // Correct for toolbar.
-div:not(.toolbar) > a {
+*:not(.toolbar) > a {
   color: var(--c-link);
 }
 

--- a/styleguide/source/assets/scss/00-base/_typography.scss
+++ b/styleguide/source/assets/scss/00-base/_typography.scss
@@ -99,26 +99,33 @@ sup {
   scroll-behavior: smooth;
   scroll-padding: 25px;
 
-  body {
+  main,
+  header {
     background-color: var(--c-bg);
     color: var(--c-text);
 
     // Small adjustment to base font size at $bp-large for `vc-*` pages
+    // This is probably fine, but might need to be in `body`
     @include breakpoint($bp-large) {
       font-size: (calc($base-font-size / 16px)) * 110%;
       line-height: $base-line-height * 1.2;
     }
   }
 
-  a:link :not(.menu-item),
-  a:visited :not(.menu-item) {
+  a:link main,
+  a:link header,
+  a:visited main,
+  a:visited header {
     color: var(--c-link);
     text-decoration: underline;
   }
 
-  a:active :not(.menu-item),
-  a:hover :not(.menu-item),
-  a:focus :not(.menu-item) {
+  a:active main,
+  a:active header,
+  a:hover main,
+  a:hover header,
+  a:focus main,
+  a:focus header {
     color: var(--c-link);
     text-decoration: none;
   }

--- a/styleguide/source/assets/scss/00-base/_typography.scss
+++ b/styleguide/source/assets/scss/00-base/_typography.scss
@@ -110,16 +110,24 @@ sup {
     }
   }
 
-  a:link :not(.menu-item),
-  a:visited :not(.menu-item) {
-    color: var(--c-link);
+  a:link,
+  a:visited {
     text-decoration: underline;
   }
 
-  a:active :not(.menu-item),
-  a:hover :not(.menu-item),
-  a:focus :not(.menu-item) {
-    color: var(--c-link);
+  a:active,
+  a:hover,
+  a:focus {
     text-decoration: none;
   }
+}
+
+// Correct for toolbar.
+div:not(.toolbar) > a {
+  color: var(--c-link);
+}
+
+// Correct for workbench tabs.
+div.workbench-tabs {
+  color: #000;
 }

--- a/styleguide/source/assets/scss/00-base/_typography.scss
+++ b/styleguide/source/assets/scss/00-base/_typography.scss
@@ -123,7 +123,7 @@ sup {
 }
 
 // Correct for toolbar.
-*:not(.toolbar) > a {
+div:not(.toolbar) > a {
   color: var(--c-link);
 }
 

--- a/styleguide/source/assets/scss/00-base/_typography.scss
+++ b/styleguide/source/assets/scss/00-base/_typography.scss
@@ -99,33 +99,26 @@ sup {
   scroll-behavior: smooth;
   scroll-padding: 25px;
 
-  main,
-  header {
+  body {
     background-color: var(--c-bg);
     color: var(--c-text);
 
     // Small adjustment to base font size at $bp-large for `vc-*` pages
-    // This is probably fine, but might need to be in `body`
     @include breakpoint($bp-large) {
       font-size: (calc($base-font-size / 16px)) * 110%;
       line-height: $base-line-height * 1.2;
     }
   }
 
-  a:link main,
-  a:link header,
-  a:visited main,
-  a:visited header {
+  a:link :not(.menu-item),
+  a:visited :not(.menu-item) {
     color: var(--c-link);
     text-decoration: underline;
   }
 
-  a:active main,
-  a:active header,
-  a:hover main,
-  a:hover header,
-  a:focus main,
-  a:focus header {
+  a:active :not(.menu-item),
+  a:hover :not(.menu-item),
+  a:focus :not(.menu-item) {
     color: var(--c-link);
     text-decoration: none;
   }

--- a/styleguide/source/assets/scss/00-base/_typography.scss
+++ b/styleguide/source/assets/scss/00-base/_typography.scss
@@ -110,15 +110,15 @@ sup {
     }
   }
 
-  a:link,
-  a:visited {
+  a:link :not(.menu-item),
+  a:visited :not(.menu-item) {
     color: var(--c-link);
     text-decoration: underline;
   }
 
-  a:active,
-  a:hover,
-  a:focus {
+  a:active :not(.menu-item),
+  a:hover :not(.menu-item),
+  a:focus :not(.menu-item) {
     color: var(--c-link);
     text-decoration: none;
   }


### PR DESCRIPTION
## JIRA Ticket(s)

- See ticket [JOE-181: ALL - Link color applied to admin toolbar](https://palantir.atlassian.net/browse/JOE-181).

## Description

The LINK text color variable in art of medicine affects the colors for the logged in admin panel menu.

Adds a css rule to ignore menu-item links.

## Testing instructions

1. See https://github.com/AmericanMedicalAssociation/code-of-ethics/pull/227
