### PR TITLE
JOE-248: Horizontal Gallery - No Arrows when only two slides are included

### DIFF
--- a/styleguide/source/assets/js/vc-hero-gallery.js
+++ b/styleguide/source/assets/js/vc-hero-gallery.js
@@ -16,7 +16,7 @@
       if (vcHeroGallery) {
         $('.vc-hero-gallery__nav').slick({
           infinite: false,
-          slidesToShow: 2,
+          slidesToShow: 1,
           slidesToScroll: 1,
           centerMode: true,
           centerPadding: '5%',

--- a/styleguide/source/assets/js/vc-horizontal-gallery.js
+++ b/styleguide/source/assets/js/vc-horizontal-gallery.js
@@ -25,7 +25,7 @@
         horizontalGalleries.each(function (e) {
           $(this).slick({
             infinite: false,
-            slidesToShow: 2,
+            slidesToShow: 1,
             slidesToScroll: 1,
             centerMode: true,
             centerPadding: '5%',


### PR DESCRIPTION
## JIRA Ticket(s)

- See ticket [JOE-248: Horizontal Gallery - No Arrows when only two slides are included](https://palantir.atlassian.net/browse/JOE-248).

## Description

Ensure arrow appears when 2 items in gallery.

## Testing instructions

1. Add a Horizontal Gallery.
3. Add exactly two slides, and publish. Note that there is no pager arrow.
5. Add a third slide, and publish. Note that the pager arrow displays.
6. Delete the third slide
7. Checkout this branch
8. Force-reload the page (SHIFT-OPT-R)
9. Pager arrows display
10. Add a third slide
11. Pager arrow dosplays

## Relevant Screenshots/gifs:

Use something like [Skitch](https://evernote.com/skitch/) or [GIPHY Capture](https://giphy.com/apps/giphycapture) to capture images/gifs to demonstrate behaviors.

## Related

https://github.com/AmericanMedicalAssociation/code-of-ethics/pull/233