### PR TITLE
JOE-251: (Tablet) Art of Medicine - Hero - Image focal point

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_vc-hero-art.scss
+++ b/styleguide/source/assets/scss/03-organisms/_vc-hero-art.scss
@@ -71,6 +71,11 @@
       opacity: 1;
     }
 
+    @media (min-width: 5em) {
+      display: block;
+      bottom: 2rem;
+    }
+
     @include breakpoint($bp-large) {
       display: block;
     }


### PR DESCRIPTION
## JIRA Ticket(s)

- See ticket [JOE-251: (Tablet) Art of Medicine - Hero - Image focal point](https://palantir.atlassian.net/browse/JOE-251).

## Description

Adjusts the position of the hero image based on screen size.

## Testing instructions

1. Create an Art of Medicine item. Use the image in the ticket for the hero element
1. Save and load the page at "tablet" size (~ 800 wide)
2. See bad image placement
3. Checkout this branch
4. Reload page
5. See good image placement

## Relevant Screenshots/gifs:

Before:

![Screenshot 2023-12-19 at 10 59 40 AM](https://github.com/AmericanMedicalAssociation/code-of-ethics/assets/360988/a7b6487a-5ada-4dbd-bcfd-9939e1ddb59f)


After:

![Screenshot 2023-12-19 at 10 59 26 AM](https://github.com/AmericanMedicalAssociation/code-of-ethics/assets/360988/410920f5-9d08-4249-b752-8c1ae02d9fcc)


## Remaining tasks

- [ ] Needs to be client tested on different devices
- [ ] Needs to be applied to the styleguide rules

## Additional Notes:

I don't know how to add this rule to the styleguide, since the 2rem seems to be a custom value.

---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)


See https://github.com/AmericanMedicalAssociation/code-of-ethics/pull/237