### PR TITLE
EWLJ-738: Update Video Play/Pause Control Script 

### DIFF
--- a/styleguide/source/assets/js/vc-video-controls.js
+++ b/styleguide/source/assets/js/vc-video-controls.js
@@ -67,8 +67,32 @@
         });
       }
 
+      // Function to play the video in the corresponding tab when a tab link is clicked
+      function playVideoInTab(tabHref) {
+          // Find the video element associated with the tab href and play the video
+          var videoElement = $(tabHref).find('iframe.youtube-iframe');
+          if (videoElement.length > 0) {
+          var playerId = videoElement.attr('id');
+          var player = youtubePlayers.find(function (p) {
+              return p.getIframe().id === playerId;
+          });
+          if (player) {
+              player.playVideo();
+          }
+          }
+      }
+
       // Load the YouTube API script
       loadScript(scriptURL, onYouTubeAPILoaded);
+
+      // Add onclick event for tab link
+      $('.vc-video-tabs__group ul a').on('click', function () {
+        // Pause all other YouTube players when the tab link is clicked
+        pauseOtherPlayers(null); // Pass null to pause all players
+      // Get the href attribute from the clicked tab link and call playVideoInTab
+      var tabHref = $(this).attr('href');
+      playVideoInTab(tabHref);
+      });
 
     },
   };

--- a/styleguide/source/assets/js/vc-video-controls.js
+++ b/styleguide/source/assets/js/vc-video-controls.js
@@ -67,21 +67,6 @@
         });
       }
 
-      // Function to play the video in the corresponding tab when a tab link is clicked
-      function playVideoInTab(tabHref) {
-          // Find the video element associated with the tab href and play the video
-          var videoElement = $(tabHref).find('iframe.youtube-iframe');
-          if (videoElement.length > 0) {
-          var playerId = videoElement.attr('id');
-          var player = youtubePlayers.find(function (p) {
-              return p.getIframe().id === playerId;
-          });
-          if (player) {
-              player.playVideo();
-          }
-          }
-      }
-
       // Load the YouTube API script
       loadScript(scriptURL, onYouTubeAPILoaded);
 
@@ -89,9 +74,6 @@
       $('.vc-video-tabs__group ul a').on('click', function () {
         // Pause all other YouTube players when the tab link is clicked
         pauseOtherPlayers(null); // Pass null to pause all players
-      // Get the href attribute from the clicked tab link and call playVideoInTab
-      var tabHref = $(this).attr('href');
-      playVideoInTab(tabHref);
       });
 
     },

--- a/styleguide/source/assets/js/vc-video-tabs.js
+++ b/styleguide/source/assets/js/vc-video-tabs.js
@@ -19,7 +19,6 @@
         const tablist = videoTabs.querySelector('ul');
         const tabs = tablist.querySelectorAll('a');
         const panels = videoTabs.querySelectorAll('[id^="section"]');
-        const allVideos = document.querySelectorAll('.vc-video-tabs__video iframe');
 
         // The tab switching function
         const switchTab = (oldTab, newTab) => {
@@ -55,11 +54,6 @@
             const currentTab = tablist.querySelector('[aria-selected]');
             if (e.currentTarget !== currentTab) {
               switchTab(currentTab, e.currentTarget);
-            }
-
-            // Pause videos when clicked
-            for (let i = 0; i < allVideos.length; i++) {
-              allVideos[i].contentWindow.postMessage('{"event":"command", "func":"pauseVideo", "args":""}', '*');
             }
           });
 


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## JIRA Ticket(s)
[EWLJ-738: Playing Video Should Stop Other Videos](https://issues.ama-assn.org/browse/EWLJ-738)

## Description:
Moved existing tab event listener into new iFrame API implementation which is needed in order to act on a click event from a cross-domain iFrame (YouTube).  This will fix the issue that was caused by the two event listeners conflicting.

## To Test:

**Setup**

- Pull SG branch [bugfix/EWLJ-738-update-video-controls](https://github.com/AmericanMedicalAssociation/joe-style-guide/tree/bugfix/EWLJ-738-update-video-controls) from [PR](https://github.com/AmericanMedicalAssociation/joe-style-guide/pull/198) into SG directory
- Serve and link local SG
- Pull branch [bugfix/EWLJ-738-update-video-js-reference](https://github.com/AmericanMedicalAssociation/code-of-ethics/tree/bugfix/EWLJ-738-update-video-js-reference) into site directory
- Follow instructions at https://github.com/AmericanMedicalAssociation/code-of-ethics/pull/271

## Automated Test:
N/A

## Style Guide:
N/A

## Relevant Screenshots/GIFs:
N/A

## Additional Notes:

---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)
