### PR TITLE
EWLJ-747: Modify Gallery Modal Styling to Prevent Covering Up Long "Media Used" Text

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_vc-horizontal-gallery.scss
+++ b/styleguide/source/assets/scss/03-organisms/_vc-horizontal-gallery.scss
@@ -19,7 +19,7 @@
       padding: 0.25rem;
 
       @include breakpoint($bp-med) {
-        padding: 0.75rem;
+        padding: 0.5rem;
       }
 
       &[aria-disabled='true'] {
@@ -139,7 +139,7 @@
 .vc-modal__first {
   @include breakpoint($bp-med) {
     position: relative;
-    padding-inline: 2rem;
+    padding-inline: 2.75rem;
     grid-column: 2 / 12;
 
     // Update grid span when `vc-modal__second` displays


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## JIRA Ticket(s)
[EWLJ-747: Gallery Exhibition - "Media Used" text covered by modal navigation arrows](https://issues.ama-assn.org/browse/EWLJ-747)

## Description:
On Gallery Exhibition pages, when longer "Media Used" text is used for a Gallery Item, it is covered up by the navigation arrows when the image is opened in the gallery carousel modal.

## To Test:

- Pull SG branch [feature/EWLJ-747-media-used-text-covered-by-modal-navigation-arrows](https://github.com/AmericanMedicalAssociation/joe-style-guide/tree/feature/EWLJ-747-media-used-text-covered-by-modal-navigation-arrows) into SG directory
- Serve and link SG
- Run lando drush @journalofethics.local cr in root directory
- Go to http://journalofethics.lndo.site/ and login as administrator
- Create or edit a Gallery Exhibition page that contains a Horizontal Gallery component with one or more Gallery Items.
  - Enter enough text in the Copyright and Media Used fields (for one or all Gallery Items) to fill the entire input
- Save the page
- Scroll to the carousel containing the gallery items and click on an image to open the modal
- Verify that the Copyright and Media Used text you entered is not covered up by the modal navigation arrows (left/right)
- Test the page with both light and dark values set for the page theme (under Hero & Theme tab) and verify the navigation circle/arrow appears as expected

## Automated Test:
N/A

## Style Guide:
N/A

## Relevant Screenshots/GIFs:
**BEFORE**
![image](https://github.com/AmericanMedicalAssociation/joe-style-guide/assets/112415930/b99a1896-2e6b-4fbf-9f12-3224911abd2c)

**AFTER**
![image](https://github.com/AmericanMedicalAssociation/joe-style-guide/assets/112415930/9c998826-55e3-4eba-afd5-267e95bef040)


## Additional Notes:
N/A
---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)
