### PR TITLE
EWLJ-733: Fix Height for Mobile/Tablet Social Icons

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_utility-nav.scss
+++ b/styleguide/source/assets/scss/02-molecules/_utility-nav.scss
@@ -91,7 +91,7 @@
       margin-right: 0;
 
       .social-icon {
-        height: 23px;
+        height: 36px;
         width: 26px;
         position: relative;
         border-left-color: transparent;

--- a/styleguide/source/assets/scss/02-molecules/_utility-nav.scss
+++ b/styleguide/source/assets/scss/02-molecules/_utility-nav.scss
@@ -77,11 +77,6 @@
           border-left-color: transparent;
         }
       }
-      > .social {
-        .social-icon {
-
-        }
-      }
     }
     //icon styling
     &.social {


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## JIRA Ticket(s)
[EWLJ-733 JOE - Sizing on social media icons on mobile or tablet](https://issues.ama-assn.org/browse/EWLJ-733)

## Description:
Social media icons are not sized properly on tablet and mobile displays for certain content types.

## To Test:

- Pull SG branch [feature/EWLJ-748-sizing-social-media-icons](https://github.com/AmericanMedicalAssociation/joe-style-guide/tree/feature/EWLJ-748-sizing-social-media-icons) into SG directory
- Serve and link SG
- Run `lando drush @journalofethics.local cr` in root directory
- Go to http://journalofethics.lndo.site/
- Visit a page for each of the following content types and verify that the social icons are displayed as expected (screenshots):
  - Gallery
  - Gallery Exhibition
  - Podcast
  - Videocast
  - Article
  - Basic Page

## Automated Test:
N/A

## Style Guide:
N/A

## Relevant Screenshots/GIFs:
**BEFORE**
![image](https://github.com/AmericanMedicalAssociation/joe-style-guide/assets/112415930/8ecc3a2c-e655-40e0-a1d3-dc1946fa6990) ![image](https://github.com/AmericanMedicalAssociation/joe-style-guide/assets/112415930/81354755-bd25-46cd-a448-7cd1691c0511)


**AFTER**
![social-icons-resized-1](https://github.com/AmericanMedicalAssociation/joe-style-guide/assets/112415930/634d1145-e915-4c11-adfd-8a771a818990) ![social-icons-resized-2](https://github.com/AmericanMedicalAssociation/joe-style-guide/assets/112415930/f1c50b9a-6913-44cc-bda9-ec7579b6ba0d)



## Additional Notes:
N/A
---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)
