### PR TITLE
EWLJ-809: Apply CSS fixes to ensure references remain left-aligned in…

### DIFF
--- a/styleguide/source/assets/scss/00-base/_rtl.scss
+++ b/styleguide/source/assets/scss/00-base/_rtl.scss
@@ -19,5 +19,10 @@ article[dir='rtl'] {
   footer.joe__article-footer p {
     text-align: right;
   }
+
+  .joe__references__list {
+    text-align: left;
+    direction: ltr;
+  }
 }
 


### PR DESCRIPTION

## Ticket(s)


**Jira Ticket**

- [EWLJ-809: 3 - R to L Formatting Issues with Articles Translated to Arabic](https://ama-it.atlassian.net/browse/EWLJ-809)


## Description

This CSS code snippet is strategically overriding the default RTL behavior for a specific element within your RTL articles, ensuring that the references are displayed in a way that's consistent with left-to-right reading expectations.

## To Test

1. Go to this page https://joe-test.ama-assn.org/ar/article/kyf-yjb-ntaml-m-ada-hyyt-altdrys-aldhyn-ykhlqwn-byyat-tlymyt-madyt-lltlab-walmtdrbyn-almmthlyn/2024-01 
2. Scroll down and check the references section, it should be aligned to left


## Relevant Screenshots/GIFs
![numberar](https://github.com/user-attachments/assets/352dccd3-d187-48b3-85f7-b3fba3096f12)

