### PR TITLE
EWLJ-763: Ensure references flow from right to left

### DIFF
--- a/styleguide/source/assets/scss/00-base/_rtl.scss
+++ b/styleguide/source/assets/scss/00-base/_rtl.scss
@@ -19,5 +19,11 @@ article[dir='rtl'] {
   footer.joe__article-footer p {
     text-align: right;
   }
+  /* Ensure references flow from right to left */
+  sup,
+  .superscript-reference {
+    direction: rtl;
+    unicode-bidi: bidi-override; /* For better browser compatibility */
+  }
 }
 

--- a/styleguide/source/assets/scss/00-base/_rtl.scss
+++ b/styleguide/source/assets/scss/00-base/_rtl.scss
@@ -19,13 +19,14 @@ article[dir='rtl'] {
   footer.joe__article-footer p {
     text-align: right;
   }
-<<<<<<< EWLJ-763-1-r-to-l-formatting-issues-with-articles-translated-to-arabic
+
   /* Ensure references flow from right to left */
   sup,
   .superscript-reference {
     direction: rtl;
     unicode-bidi: bidi-override; /* For better browser compatibility */
-=======
+  }
+
   .article_abstract {
     > h2 {
       text-align: left;
@@ -33,7 +34,6 @@ article[dir='rtl'] {
     p:first-of-type:not([dir="rtl"]) {
       text-align: left;
     }
->>>>>>> develop
   }
 }
 


### PR DESCRIPTION
## Ticket(s)


**Jira Ticket**

- [EWLJ-763: 1 - R to L Formatting Issues with Articles Translated to Arabic](https://ama-it.atlassian.net/browse/EWLJ-763)


## Description
Apply CSS fix to ensure correct display of superscript references in RTL articles.

## To Test

- Go to this page https://joe-test.ama-assn.org/ar/article/kyf-yjb-ntaml-m-ada-hyyt-altdrys-aldhyn-ykhlqwn-byyat-tlymyt-madyt-lltlab-walmtdrbyn-almmthlyn/2024-01
- Scroll down and check the sup tags, it should be RTL

## Relevant Screenshots/GIFs
![suptags](https://github.com/user-attachments/assets/ac1fca60-c2b6-4efa-889c-f748c56e3f2c)

