### PR TITLE
EWLJ-811: Author Information section right justified - RTL SCSS

### DIFF
--- a/styleguide/source/assets/scss/00-base/_rtl.scss
+++ b/styleguide/source/assets/scss/00-base/_rtl.scss
@@ -12,12 +12,13 @@ article[dir='rtl'] {
     direction: rtl;
   }
 
-  .joe__page-content--article {
+  footer.joe__article-footer {
+    text-align: left;
+    direction: ltr;
+  }
+
+  h3.joe__title-label {
     text-align: left;
   }
 
-  footer.joe__article-footer p {
-    text-align: right;
-  }
 }
-


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)
5 - R to L Formatting Issues with Articles Translated to Arabic

**Jira Ticket**
[EWLJ-811](https://ama-it.atlassian.net/browse/EWLJ-811)

## Description

Author bio in the Author Information section needs to be right justified. 


## To Test

1. Go to this page https://joe-test.ama-assn.org/ar/article/kyf-yjb-ntaml-m-ada-hyyt-altdrys-aldhyn-ykhlqwn-byyat-tlymyt-madyt-lltlab-walmtdrbyn-almmthlyn/2024-01
2. Scroll down and check the **Author Information section**, it should be right justified.



## Visual Regressions

N/A


## Relevant Screenshots/GIFs

![Screenshot 2024-09-05 at 10-10-58 The American Medical Association on the Ethics of Vivisection 1880-1950 Journal of Ethics American Medical Association](https://github.com/user-attachments/assets/078d311f-a967-4cea-b797-517adff3a4d3)


## Remaining Tasks

N/A


## Additional Notes
- are there any PRs in this or other repositories that relate to or affect this PR?
- EWLJ-809



[EWLJ-811]: https://ama-it.atlassian.net/browse/EWLJ-811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ