### PR TITLE
EWLJ-808: Fix RTL Abstract ordering in articles

### DIFF
--- a/styleguide/source/assets/scss/00-base/_rtl.scss
+++ b/styleguide/source/assets/scss/00-base/_rtl.scss
@@ -19,5 +19,13 @@ article[dir='rtl'] {
   footer.joe__article-footer p {
     text-align: right;
   }
+  .article_abstract {
+    > h2 {
+      text-align: left;
+    }
+    p:first-of-type:not([dir="rtl"]) {
+      text-align: left;
+    }
+  }
 }
 


### PR DESCRIPTION

**Jira Ticket**

- [EWLJ-808:2 - R to L Formatting Issues with Articles Translated to Arabic](https://ama-it.atlassian.net/browse/EWLJ-808)


## Description

Fix RTL Abstract ordering in articles


## To Test

1. Go to this page https://joe-test.ama-assn.org/ar/article/kyf-yjb-ntaml-m-ada-hyyt-altdrys-aldhyn-ykhlqwn-byyat-tlymyt-madyt-lltlab-walmtdrbyn-almmthlyn/2024-01
2. Scroll down and check the Author Information section, it should be right justified.


## Relevant Screenshots/GIFs

![cssclass](https://github.com/user-attachments/assets/660fcab7-4005-429e-8f1b-222fd066504b)



## Additional Notes

Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
This style depends on adding a class on the field, The PR needed is https://github.com/AmericanMedicalAssociation/code-of-ethics/pull/292