### PR TITLE
EWJL-812: Style changes in Arabic articles appearing in articles page

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_article-teaser.scss
+++ b/styleguide/source/assets/scss/03-organisms/_article-teaser.scss
@@ -130,6 +130,10 @@
   }
 }
 
+.joe__article-teaser__title_ar {
+  text-align: end; /* RTL */
+} 
+
 .joe__article-teaser__meta {
   @extend %joe__type--smaller;
   display: block;
@@ -147,7 +151,17 @@
 .joe__article-teaser__desc {
   @extend %joe__type--smaller;
   margin-top: .5em;
+  text-align: start; /* LTR */
 }
+
+.joe__article-teaser__desc_ar {
+  @extend %joe__type--smaller;
+  margin-top: .5em;
+  text-align: end; /* RTL */
+}
+
+
+
 
 .joe__article-teaser--large {
   flex-direction: column;


### PR DESCRIPTION
Arabic articles that appear when the Article listing page is filtered by Arabic need to right justify the Title and Issue Summary Text since these are in Arabic and being read from right to left.

## JIRA Ticket(s)

- See ticket [EWLJ-812: Arabic articles in Article listing page filtered by Arabic](https://ama-it.atlassian.net/browse/EWLJ-812).

## Description

 - Modified the Title and Summary styles at "_article-teaser.scss" to right justify Arabic Title and Summary on Article listing page.
 - Other changes are present at the main repository at https://github.com/AmericanMedicalAssociation/code-of-ethics/pull/294  

## Testing instructions

1. Go to Article listing page
2. use the filter to display Arabic articles
3. Articles in Arabic should be displayed from right to left.


## Relevant Screenshots/gifs:
![Screenshot 2024-09-11 at 16-48-36 Articles Journal of Ethics American Medical Association](https://github.com/user-attachments/assets/89f847d4-a5c3-4de6-aa94-178ebf5b2aa0)


## Remaining tasks

N/A

## Additional Notes:
Other changes related to this activity were commited to the main repository: 
https://github.com/AmericanMedicalAssociation/code-of-ethics/pull/294
**Please merge both PR together.**

---