### PR TITLE
EWLJ-812: hotfix ar content title will use same styles as English

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_article-teaser.scss
+++ b/styleguide/source/assets/scss/03-organisms/_article-teaser.scss
@@ -124,13 +124,24 @@
     text-decoration: underline;
     border-bottom: 0;
   }
-
-  p[dir="RTL"] {
-    text-align: right; // For right to left language titles.
-  }
 }
 
 .joe__article-teaser__title_ar {
+  @include type($font-serif, 1.05em, $font-weight-bold, 1.25);
+  margin-top: .6em;
+
+  a:link,
+  a:visited {
+    color: $black;
+    border-bottom: 0;
+  }
+
+  a:active,
+  a:hover,
+  a:focus {
+    text-decoration: underline;
+    border-bottom: 0;
+  }
   text-align: end; /* RTL */
 } 
 


### PR DESCRIPTION
Hotfix to display Arabic title content with same styles as English

<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

**Jira Ticket**

- [EWLJ-812: 6 - R to L Formatting Issues with Articles Translated to Arabic](https://ama-it.atlassian.net/browse/EWLJ-812)


## Description
Hotfix to display Arabic title content with same styles as English


## To Test

1. Go to Article listing page
2. use the filter to display Arabic articles
3. Articles titles in Arabic should be displayed with same styles as English.



## Relevant Screenshots/GIFs
![Screenshot 2024-09-13 at 17-08-25 Articles Journal of Ethics American Medical Association](https://github.com/user-attachments/assets/36d97f34-0d29-428a-9856-131112a87711)



## Remaining Tasks

N/A


## Additional Notes

Anything more to add? Good things to call out here are:
N/A
