### PR TITLE
EWLJ-794: Social Media Icons on Art Exhibition Pages

### DIFF
--- a/styleguide/source/assets/scss/00-base/_slick.scss
+++ b/styleguide/source/assets/scss/00-base/_slick.scss
@@ -278,4 +278,10 @@
       }
     }
   }
+
+  .joe__primary-nav {
+    ul > .joe__utility-nav__item:first-child {
+      display: none;
+    }
+  }
 }


### PR DESCRIPTION
## Ticket(s)


**Jira Ticket**

- [EWLJ-794: Social Media Icons on Art Exhibition Pages](https://ama-it.atlassian.net/browse/EWLJ-794)


## Description

This CSS hide the "Art Exhibition" on the main menu ONLY for the Art Exhibition page.


## To Test
-  Make sure to generate the style with gulp
- Run lando drush @journalofethics.local cr
- Go to Main page and click on Top link "Art Exhibition"



## Relevant Screenshots/GIFs

![ArtMainMenu](https://github.com/user-attachments/assets/469efffa-c357-4f70-b102-c2758dc4d1e5)

The menu still shows on other pages
![keeparthexhi](https://github.com/user-attachments/assets/0106b1c4-f21d-4ed1-826c-8e768b5dda24)


