### PR TITLE
EWLJ-709: Add H2 Flag Type Style Overrides

### DIFF
--- a/styleguide/source/_patterns/02-molecules/wordmark.twig
+++ b/styleguide/source/_patterns/02-molecules/wordmark.twig
@@ -1,6 +1,6 @@
 <div class="joe__wordmark">
   <a href="">
-    <h1 class="joe__wordmark__title">{{ wordmark.title }}{% if wordmark.tm %}<sup>&reg;</sup>{% endif %}</h1>
-    <h2 class="joe__wordmark__subtitle">{{ wordmark.subtitle }}</h2>
+    <div class="joe__wordmark__title">{{ wordmark.title }}{% if wordmark.tm %}<sup>&reg;</sup>{% endif %}</div>
+    <div class="joe__wordmark__subtitle">{{ wordmark.subtitle }}</div>
   </a>
 </div>

--- a/styleguide/source/assets/scss/01-atoms/_flag.scss
+++ b/styleguide/source/assets/scss/01-atoms/_flag.scss
@@ -32,25 +32,20 @@
   @include type($font-serif, .75em, $font-weight-medium, 1.25);
   padding: 2em 10px 10px;
   top: -1.3em;
-  
   .joe__flag__type {
     display: block;
   }
-  
   .joe__poll & {
     top: -2em;
   }
-  
   .joe__issue-listing--current & {
     top: -2.7em;
     padding-top: 2em;
 
   }
-  
   @include breakpoint($bp-med) {
     padding: 2.75em 12px 10px;
     top: -2em;
-    
     .joe__poll & {
       top: -2.7em;
     }
@@ -85,4 +80,9 @@
 .joe__flag--blue {
   background-color: $navy-lighter;
   background: $blue-gradient;
+}
+// Override H2 flag type.
+h2.joe__flag__type {
+  font-size: 1em;
+  margin: 0;
 }

--- a/styleguide/source/assets/scss/01-atoms/_headings.scss
+++ b/styleguide/source/assets/scss/01-atoms/_headings.scss
@@ -8,7 +8,10 @@ h1,
   margin-top: 2em;
 }
 
-h2,
+h2
+:not(.vc-hero-art__flag-type)
+:not(.vc-hero-gallery__flag-type)
+:not(.vc-hero-gallery__flag-type),
 .joe__h2,
 %joe__h2 {
   // Mobile (default)
@@ -57,7 +60,10 @@ h6,
 :root[class*='vc-'] {
 
   h1,
-  h2,
+  h2
+  :not(.vc-hero-art__flag-type)
+  :not(.vc-hero-gallery__flag-type)
+  :not(.vc-hero-gallery__flag-type),
   h3,
   h4,
   h5,
@@ -75,7 +81,10 @@ h6,
     line-height: 1;
   }
 
-  h2 {
+  h2
+    :not(.vc-hero-art__flag-type)
+    :not(.vc-hero-gallery__flag-type)
+    :not(.vc-hero-gallery__flag-type) {
     font-size: clamp(2rem, 1.444rem + 2.468vw, 3.45rem);
   }
 

--- a/styleguide/source/assets/scss/02-molecules/_wordmark.scss
+++ b/styleguide/source/assets/scss/02-molecules/_wordmark.scss
@@ -1,20 +1,20 @@
 .joe__wordmark {
-  
+
   .joe__footer & {
     @extend %clearfix;
     display: inline-block;
   }
-  
+
   @include breakpoint($bp-med) {
     margin-top: 3px;
     margin-bottom: 10px;
   }
-  
+
   a:link,
   a:visited {
     color: $black-90;
   }
-  
+
   a:active,
   a:hover,
   a:focus {
@@ -26,29 +26,29 @@
   @include type($font-serif, 1.2em, $font-weight-bold, 1.3);
   margin-bottom: 0;
   margin-top: 0;
-  
+
   sup {
     font-family: $font-sans-serif;
     font-weight: $font-weight-medium;
     font-size: .5em;
   }
-  
+
   .joe__footer & {
     @include type($font-serif, 1.2em, $font-weight-bolder, 1.3);
   }
-  
+
   @include breakpoint($bp-small) {
     @include type($font-serif, 1.55em, $font-weight-bold, 1.28);
     margin-top: 8px;
-    
+
     .joe__footer & {
       @include type($font-serif, 1.4em, $font-weight-bold, 1.3);
     }
   }
-  
+
   @include breakpoint($bp-med) {
     font-weight: $font-weight-bolder;
-    
+
     .joe__footer & {
       font-weight: $font-weight-bolder;
     }
@@ -59,19 +59,20 @@
   @include type($font-sans-serif, .85em, $font-weight-medium, 1.15);
   font-style: italic;
   margin-top: 0;
-  
+  margin-bottom: 6px;
+
   .joe__footer & {
     @include type($font-sans-serif, 0.85em, $font-weight-medium, 1.15);
   }
-  
+
   @include breakpoint($bp-small) {
     @include type($font-sans-serif, 1.1em, $font-weight-medium, 1.28);
-    
+
     .joe__footer & {
       @include type($font-sans-serif, 0.95em, $font-weight-medium, 1.15);
     }
   }
-  
+
 }
 
 

--- a/styleguide/source/assets/scss/03-organisms/_vc-hero-art.scss
+++ b/styleguide/source/assets/scss/03-organisms/_vc-hero-art.scss
@@ -353,3 +353,15 @@
     margin-left: -9px;
   }
 }
+
+// Override h2 flag type styles.
+h2.vc-hero-gallery__flag-type {
+  margin-top: 6px;
+  margin-bottom: 4px;
+}
+h2.vc-hero-art__flag-type {
+  margin: 0;
+  @include breakpoint(max-width $bp-med) {
+    font-size: 18px;
+  }
+}

--- a/styleguide/source/assets/scss/03-organisms/_vc-hero-ethics.scss
+++ b/styleguide/source/assets/scss/03-organisms/_vc-hero-ethics.scss
@@ -299,3 +299,7 @@
     filter: brightness(0%);
   }
 }
+// Override H2 flag type.
+h2.vc-hero-ethics__flag-type {
+  display: inline;
+}

--- a/styleguide/source/assets/scss/05-pages/_gallery.scss
+++ b/styleguide/source/assets/scss/05-pages/_gallery.scss
@@ -506,6 +506,10 @@ $header-spacer-height-mobile: calc((#{$header-top-bottom-padding-mobile} * 2) + 
             margin-bottom: 1.5em;
             margin-top: 0;
           }
+          // Override H2 flag type.
+          h2.joe__flag__type {
+            margin-bottom: 0;
+          }
           .title {
             margin-bottom: .5em;
             @include breakpoint($bp-med) {


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## JIRA Ticket(s)
[EWLJ-709: SEO - Enhance H1, H2, H3 schema on article HTML and XML pages](https://ama-it.atlassian.net/browse/EWLJ-709)

## Description:
Update styling for flag type elements changed to H2 elements.

## To Test:

**Setup**

- Pull SG branch [feature/EWLJ-709-update-flag-type-css](https://github.com/AmericanMedicalAssociation/joe-style-guide/tree/feature/EWLJ-709-update-flag-type-css) into SG directory
- Serve SG
- Follow testing instructions at https://github.com/AmericanMedicalAssociation/code-of-ethics/pull/293

## Automated Test:
N/A

## Style Guide:
N/A

## Relevant Screenshots/GIFs:
N/A

## Additional Notes:
N/A
---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)


[EWLJ-709]: https://ama-it.atlassian.net/browse/EWLJ-709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ