### PR TITLE
EWLJ-822: style for fix issue on rtl articles page

### DIFF
--- a/styleguide/source/assets/scss/00-base/_rtl.scss
+++ b/styleguide/source/assets/scss/00-base/_rtl.scss
@@ -50,10 +50,18 @@ article[dir='rtl'] {
     text-align: left;
     direction: ltr;
   }
-  
+
   .joe__tags {
     text-align: left;
     direction: ltr;
   }
 
+  /* Ensure title and summary fields are aligned to right */
+  .joe__article-teaser__block {
+    .joe__article-teaser__title,
+    .joe__article-teaser__desc {
+      text-align: right;
+      direction: rtl;
+    }
+  }
 }


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

Please do not submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**

- N/A

**Jira Ticket**

- [EWLJ-822X: Article listing page bug when selecting multiple languages](https://ama-it.atlassian.net/browse/EWLJ-822)


## Description

Explain the technical implementation of the work done.


## To Test
This will require this one https://github.com/AmericanMedicalAssociation/code-of-ethics/pull/314
-  lando drush @journalofethics.local cr
- Compile assets
- On your local go to page: http://journalofethics.lndo.site:8000/articles?field_language%5Bes%5D=es&field_language%5Bar%5D=ar
- Review screenshots

## Visual Regressions

N/A

## Relevant Screenshots/GIFs

![Articles-BUGSOLVED](https://github.com/user-attachments/assets/3e3750e1-71c2-4dc9-ad58-91111d173c31)



## Remaining Tasks

Remaining tasks?
PR RELATED TO THIS ONE https://github.com/AmericanMedicalAssociation/code-of-ethics/pull/314

## Additional Notes

Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
-  PR RELATED TO THIS ONE https://github.com/AmericanMedicalAssociation/code-of-ethics/pull/314

