### PR TITLE
EWLJ-831: Spacing modifications to Read In translation text

### DIFF
--- a/styleguide/source/assets/scss/05-pages/_article.scss
+++ b/styleguide/source/assets/scss/05-pages/_article.scss
@@ -3,7 +3,7 @@
   background: linear-gradient(rgba($white, .75) 0%, $white 100%);
   position: relative;
   padding-top: 1em;
-  
+
   // create shadow corner effect
   &:before {
     content: "";
@@ -20,7 +20,7 @@
     min-height: 450px;
     max-height: 600px;
   }
-  
+
   @include breakpoint($bp-med) {
     padding-top: 1.5em;
   }
@@ -33,4 +33,16 @@
 .joe__article--bottom {
   @include gutter($margin-bottom-full...);
   background-color: $white;
+}
+
+.available__in {
+  display: flex;
+  align-items: center;
+  .joe__tags-title {
+    padding-top: 3px;
+    letter-spacing: 0;
+  }
+  .joe__tags-list li {
+    border-bottom: 0;
+  }
 }

--- a/styleguide/source/assets/scss/05-pages/_article.scss
+++ b/styleguide/source/assets/scss/05-pages/_article.scss
@@ -39,10 +39,14 @@
   display: flex;
   align-items: center;
   .joe__tags-title {
-    padding-top: 3px;
+    padding-top: 0.3em;
     letter-spacing: 0;
   }
   .joe__tags-list li {
     border-bottom: 0;
+
+    > a {
+      font-size: 0.95em;
+    }
   }
 }


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

**Jira Ticket**

- [EWLJ-831: Spacing modifications to Read In translation text](https://ama-it.atlassian.net/browse/EWLJ-831)


## Description

Add style to the available__in to show the links in the same line with the Label.


## To Test
1. Go to articles pages.
2. Filter by language.
3. Review the "Read in" links will be in the same line.

Check screenshots to have an idea.

## Visual Regressions



## Relevant Screenshots/GIFs
![inline1](https://github.com/user-attachments/assets/c03e804c-774e-4091-8d95-0bb7e05207a9)
![inline2](https://github.com/user-attachments/assets/739af68c-cb34-431d-82e1-3f472cc8444d)



## Remaining Tasks



## Additional Notes


