### PR TITLE
EWLJ-784: Modified caption field position on Mobile devices.

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_vc-layout-paragraphs.scss
+++ b/styleguide/source/assets/scss/03-organisms/_vc-layout-paragraphs.scss
@@ -143,64 +143,70 @@
     }
   }
 
-  // TWO COLUMNS - LARGER RIGHT COL
-  .layout--twocol-larger-right-col {
-    @extend .vc-container;
-  
-    .vc-container {
-      --container-padding: 0;
-    }
-  
-    display: grid;
-    grid-template-columns: 5fr 7fr;
-    gap: 16px;
-    align-items: center;
-  
-    > .layout__region {
-      border: 0;
-      margin: 0;
-    }
-  
-    @include breakpoint($bp-med) {
-      > .layout__region--first {
-        grid-column: 1;
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        align-items: flex-start;
-        height: 100%;
-  
-        p {
-          margin: 0;
-        }
-      }
-  
-      > .layout__region--second {
-        grid-column: 2;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        height: 100%;
-      }
-    }
-  
-    @media (max-width: $bp-med) {
+// TWO COLUMNS - LARGER RIGHT COL
+.layout--twocol-larger-right-col {
+  @extend .vc-container;
+
+  .vc-container {
+    --container-padding: 0;
+  }
+
+  display: grid;
+  grid-template-columns: 5fr 7fr; // Adjusted for even spacing similar to left layout
+  gap: 24px;
+  align-items: start;
+
+  > .layout__region {
+    border: 0;
+    margin: 0;
+  }
+
+  @include breakpoint($bp-med) {
+    > .layout__region--first {
+      grid-column: 1;
       display: flex;
       flex-direction: column;
-  
-      > .layout__region--first {
-        order: 2;
-        width: 100%;
-      }
-  
-      > .layout__region--second {
-        order: 1;
-        display: flex;
-        align-items: center;
-        justify-content: center;
+      justify-content: center;
+      align-items: flex-start;
+      height: 100%;
+
+      p {
+        margin: 0;
       }
     }
+
+    > .layout__region--second {
+      grid-column: 2;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      height: 100%;
+      padding-left: 24px; // Add spacing similar to the left layout
+    }
   }
+
+  @media (max-width: $bp-med) {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    > .layout__region--first {
+      order: 2;
+      width: 100%;
+      padding: 10px 0; // Consistent padding across layouts
+    }
+
+    > .layout__region--second {
+      order: 1;
+      width: 100%;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      padding: 0; // Ensure no extra padding on mobile
+    }
+  }
+}
+
   
 
 

--- a/styleguide/source/assets/scss/03-organisms/_vc-layout-paragraphs.scss
+++ b/styleguide/source/assets/scss/03-organisms/_vc-layout-paragraphs.scss
@@ -146,33 +146,63 @@
   // TWO COLUMNS - LARGER RIGHT COL
   .layout--twocol-larger-right-col {
     @extend .vc-container;
-
+  
     .vc-container {
       --container-padding: 0;
     }
-
-    >.layout__region {
+  
+    display: grid;
+    grid-template-columns: 5fr 7fr;
+    gap: 16px;
+    align-items: center;
+  
+    > .layout__region {
       border: 0;
       margin: 0;
     }
-
+  
     @include breakpoint($bp-med) {
-      .layout__region--top {
-        grid-column: span 12;
-        margin: 0;
+      > .layout__region--first {
+        grid-column: 1;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: flex-start;
+        height: 100%;
+  
+        p {
+          margin: 0;
+        }
       }
-
-      >.layout__region--first {
-        grid-column: span 5;
-        margin: 0;
+  
+      > .layout__region--second {
+        grid-column: 2;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        height: 100%;
       }
-
-      >.layout__region--second {
-        grid-column: span 7;
-        margin: 0;
+    }
+  
+    @media (max-width: $bp-med) {
+      display: flex;
+      flex-direction: column;
+  
+      > .layout__region--first {
+        order: 2;
+        width: 100%;
+      }
+  
+      > .layout__region--second {
+        order: 1;
+        display: flex;
+        align-items: center;
+        justify-content: center;
       }
     }
   }
+  
+
 
   .layout__region.is-zoomed {
     position: absolute;


### PR DESCRIPTION
## JIRA Ticket(s)

- See ticket [EWLJ-784](https://ama-it.atlassian.net/jira/software/c/projects/EWLJ/boards/357?selectedIssue=EWLJ-784).

## Description

Caption placement for Featured Image component on Desktop versus Tablet/Mobile.}

Given: Individual has accessed JOE website When the user accesses the website through a tablet or mobile device Then they should be able to view the captions for all Featured Image layout types centered **below the image**.

## Testing instructions

1. Run "lando gulp" at styleguide/joe-style-guide/styleguide
2. Create a "Feature image" on the "Ethics Close Up" content type.
3. `Test mobile and tablet displays`.
4. Caption field should be below the image.

## Relevant Screenshots/gifs:
Mobile
![Screenshot 2024-10-18 at 11-42-11 EWLJ-784 Journal of Ethics American Medical Association](https://github.com/user-attachments/assets/764f182b-621a-4770-b726-0b57e815d726)

Tablet
![Screenshot 2024-10-18 at 11-41-47 EWLJ-784 Journal of Ethics American Medical Association](https://github.com/user-attachments/assets/116d9158-faa1-45fc-94ac-d13fd7c07b98)


[EWLJ-784]: https://ama-it.atlassian.net/browse/EWLJ-784?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ