### PR TITLE
EWLJ-820: Art Exhibition Link in Hamburger Menu for AE/AOM/ECU Content Types

### DIFF
--- a/styleguide/source/assets/scss/00-base/_slick.scss
+++ b/styleguide/source/assets/scss/00-base/_slick.scss
@@ -278,10 +278,4 @@
       }
     }
   }
-
-  .joe__primary-nav {
-    ul > .joe__utility-nav__item:first-child {
-      display: none;
-    }
-  }
 }


### PR DESCRIPTION

## Ticket(s)


**Github Issue**


**Jira Ticket**

- [EWLJ-820: Art Exhibition Link in Hamburger Menu for AE/AOM/ECU Content Types](https://ama-it.atlassian.net/browse/EWLJ-820)


## Description

This change will restore the visibility of the navigation item on the social links for AE, AOM, and ECU content types. The UI will be updated to hide these links for other content types.

## To Test
- Compile assets
- Clear caches
- Go to art exhibition page and you will see the link again.

## Visual Regressions

![restorelink](https://github.com/user-attachments/assets/cbc357ef-aa66-44fa-8362-2078ac5fc449)


## Relevant Screenshots/GIFs



## Remaining Tasks



## Additional Notes
