### PR TITLE
EWLJ-840: Formatting of Related Articles Section on Arabic Article Page

### DIFF
--- a/styleguide/source/assets/scss/00-base/_rtl.scss
+++ b/styleguide/source/assets/scss/00-base/_rtl.scss
@@ -64,4 +64,16 @@ article[dir='rtl'] {
       direction: rtl;
     }
   }
+
+  /* Ensure title and summary fields are aligned to left IF direction is ltr */
+  article[dir='ltr'] {
+    .joe__article-teaser__block {
+      .joe__article-teaser__title,
+      .joe__article-teaser__desc {
+        text-align: left;
+        direction: ltr;
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)


**Github Issue**

- [Issue XXX: EWLJ-840: Formatting of Related Articles Section on Arabic Article Page](https://github.com/AmericanMedicalAssociation/code-of-ethics/pull/346)

**Jira Ticket**

- [EWLJ-840: Formatting of Related Articles Section on Arabic Article Page](https://ama-it.atlassian.net/browse/EWLJ-840)


## Description

The CSS applies to the article with dir = ltr Inside in Article with dir = rtl

## To Test

- [ ] Follow the steps in  https://github.com/AmericanMedicalAssociation/code-of-ethics/pull/346

1. Oncode-of-ethics checkout branch EWLJ-840
2. Compile the theme
3. Run lando drush @journalofethics.local cr
4. Go to an Arabic article
5. Validate the content in block "You may also be interested in" is aligned properly.

## Visual Regressions


## Relevant Screenshots/GIFs

![alignment](https://github.com/user-attachments/assets/4e83ded5-04c1-4690-b709-46f37f48ad83)


## Remaining Tasks

Remaining tasks?


## Additional Notes

Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
PR needs approval   https://github.com/AmericanMedicalAssociation/code-of-ethics/pull/346
