### PR TITLE
EWLJ-764: Updated tab functionality to handle multiple sets of tabs.

### DIFF
--- a/styleguide/source/assets/js/vc-video-tabs.js
+++ b/styleguide/source/assets/js/vc-video-tabs.js
@@ -26,6 +26,17 @@
         const tabs = tablist.querySelectorAll('a');
         const panels = videoTabs.querySelectorAll('[id^="section"]');
 
+        // EWLJ-764: Helper function to resize iframe videos when tab is activated or page loads
+        const resizeIframe = () => {
+          panels.forEach(panel => {
+            const iframe = panel.querySelector('iframe');
+            if (iframe) {
+              iframe.style.height = '100%';
+              iframe.style.width = '100%';
+            }
+          });
+        };
+
         // The tab switching function
         const switchTab = (oldTab, newTab) => {
           // EWLJ-764: Prevent focus issues in Safari by adding a small delay on focus
@@ -43,6 +54,9 @@
           const oldIndex = Array.prototype.indexOf.call(tabs, oldTab);
           panels[oldIndex].hidden = true;
           panels[index].hidden = false;
+
+          // EWLJ-764: Resize iframe when tab is activated
+          resizeIframe();
         };
 
         // EWLJ-764: Add the tablist role to the first <ul> in the .vc-video-tabs__group container
@@ -92,16 +106,11 @@
         tabs[0].setAttribute('aria-selected', 'true');
         panels[0].hidden = false;
         
-        // EWLJ-764: Force a resize after the first load to ensure the correct aspect ratio
-        window.addEventListener('load', () => {
-          panels.forEach(panel => {
-            const iframe = panel.querySelector('iframe');
-            if (iframe) {
-              iframe.style.height = '100%'; // Reapply height to enforce correct ratio
-              iframe.style.width = '100%';
-            }
-          });
-        });
+        // EWLJ-764: Trigger resize after the first load to ensure the correct aspect ratio
+        window.addEventListener('load', resizeIframe);
+
+        // EWLJ-764: Trigger resize on window resize to handle changes in viewport dimensions
+        window.addEventListener('resize', resizeIframe);
       });
     }
   };

--- a/styleguide/source/assets/js/vc-video-tabs.js
+++ b/styleguide/source/assets/js/vc-video-tabs.js
@@ -12,10 +12,11 @@
   Drupal.behaviors.vc_video_tabs = {
     attach: function (context, settings) {
 
-      // Tabs based on https://inclusive-components.design/videoTabs-interfaces/
-      const videoTabs = document.querySelector('.vc-video-tabs__group');
+      // EWLJ-764: Select all tab groups on the page to handle multiple sets of tabs.
+      const videoTabsGroups = document.querySelectorAll('.vc-video-tabs__group');
 
-      if (videoTabs) {
+      // EWLJ-764: Loop through each video tab group and apply tab functionality.
+      videoTabsGroups.forEach((videoTabs) => {
         const tablist = videoTabs.querySelector('ul');
         const tabs = tablist.querySelectorAll('a');
         const panels = videoTabs.querySelectorAll('[id^="section"]');
@@ -41,10 +42,10 @@
         // Add the tablist role to the first <ul> in the .vc-video-tabs__group container
         tablist.setAttribute('role', 'tablist');
 
-        // Add semantics are remove user focusability for each tab
+        // Add semantics and remove user focusability for each tab
         Array.prototype.forEach.call(tabs, (tab, i) => {
           tab.setAttribute('role', 'tab');
-          tab.setAttribute('id', `tab ${i + 1}`);
+          tab.setAttribute('id', `tab-${i + 1}`); // EWLJ-764: Updated ID format for better uniqueness
           tab.setAttribute('tabindex', '-1');
           tab.parentNode.setAttribute('role', 'presentation');
 
@@ -85,7 +86,7 @@
         tabs[0].removeAttribute('tabindex');
         tabs[0].setAttribute('aria-selected', 'true');
         panels[0].hidden = false;
-      }
+      });
     }
   };
 })(jQuery, Drupal);

--- a/styleguide/source/assets/js/vc-video-tabs.js
+++ b/styleguide/source/assets/js/vc-video-tabs.js
@@ -1,75 +1,59 @@
-/**
- * @file
- * Facets and filters
- *
- * JavaScript should be made compatible with libraries other than jQuery by
- * wrapping it with an "anonymous closure". See:
- * - https://drupal.org/node/1446420
- * - http://www.adequatelygood.com/2010/3/JavaScript-Module-Pattern-In-Depth
- */
-
 (function ($, Drupal) {
   Drupal.behaviors.vc_video_tabs = {
     attach: function (context, settings) {
-
-      // EWLJ-764: Select all tab groups on the page to handle multiple sets of tabs.
       const videoTabsGroups = document.querySelectorAll('.vc-video-tabs__group');
 
-      // EWLJ-764: Check if NodeList.forEach is supported
       if (!NodeList.prototype.forEach) {
-        NodeList.prototype.forEach = Array.prototype.forEach; // Polyfill for forEach on NodeList
+        NodeList.prototype.forEach = Array.prototype.forEach;
       }
 
-      // EWLJ-764: Loop through each video tab group and apply tab functionality.
       videoTabsGroups.forEach((videoTabs) => {
-        const tablist = videoTabs.querySelector('ul');
-        const tabs = tablist.querySelectorAll('a');
         const panels = videoTabs.querySelectorAll('[id^="section"]');
 
-        // EWLJ-764: Helper function to resize iframe videos when tab is activated or page loads
-        const resizeIframe = () => {
+        // Helper function to adjust iframe aspect ratio for mobile
+        const adjustIframeAspectRatio = () => {
           panels.forEach(panel => {
             const iframe = panel.querySelector('iframe');
             if (iframe) {
-              iframe.style.height = '100%';
+              const containerWidth = iframe.parentNode.clientWidth;
               iframe.style.width = '100%';
+              iframe.style.height = `${containerWidth * 9 / 16}px`; // Set height to maintain 16:9 ratio
             }
           });
         };
 
-        // The tab switching function
-        const switchTab = (oldTab, newTab) => {
-          // EWLJ-764: Prevent focus issues in Safari by adding a small delay on focus
-          setTimeout(() => newTab.focus(), 0);
+        // Initial adjustment and set up event listeners for mobile
+        const isMobile = window.matchMedia("(max-width: 768px)").matches;
+        if (isMobile) {
+          adjustIframeAspectRatio();
+          window.addEventListener('resize', adjustIframeAspectRatio);
+          window.addEventListener('orientationchange', adjustIframeAspectRatio);
+        }
 
-          // Make the active tab focusable by the user (Tab key)
+        // Desktop tabs functionality (unchanged from previous solutions)
+        const tablist = videoTabs.querySelector('ul');
+        const tabs = tablist.querySelectorAll('a');
+        
+        const switchTab = (oldTab, newTab) => {
+          setTimeout(() => newTab.focus(), 0);
           newTab.removeAttribute('tabindex');
           newTab.setAttribute('aria-selected', 'true');
           oldTab.removeAttribute('aria-selected');
           oldTab.setAttribute('tabindex', '-1');
-
-          // Get the indices of the new and old tabs to find the correct
-          // tab panels to show and hide
           const index = Array.prototype.indexOf.call(tabs, newTab);
           const oldIndex = Array.prototype.indexOf.call(tabs, oldTab);
           panels[oldIndex].hidden = true;
           panels[index].hidden = false;
-
-          // EWLJ-764: Resize iframe when tab is activated
-          resizeIframe();
+          adjustIframeAspectRatio();
         };
 
-        // EWLJ-764: Add the tablist role to the first <ul> in the .vc-video-tabs__group container
         tablist.setAttribute('role', 'tablist');
 
-        // EWLJ-764: Add semantics and remove user focusability for each tab
         tabs.forEach((tab, i) => {
           tab.setAttribute('role', 'tab');
-          tab.setAttribute('id', `tab-${i + 1}`); // EWLJ-764: Updated ID format for better uniqueness
+          tab.setAttribute('id', `tab-${i + 1}`);
           tab.setAttribute('tabindex', '-1');
           tab.parentNode.setAttribute('role', 'presentation');
-
-          // EWLJ-764: Handle clicking of tabs for mouse users
           tab.addEventListener('click', (e) => {
             e.preventDefault();
             const currentTab = tablist.querySelector('[aria-selected="true"]');
@@ -77,8 +61,6 @@
               switchTab(currentTab, e.currentTarget);
             }
           });
-
-          // EWLJ-764: Handle keydown events for keyboard users with cross-browser support
           tab.addEventListener('keydown', (e) => {
             const index = Array.prototype.indexOf.call(tabs, e.currentTarget);
             const dir = e.key === 'ArrowLeft' ? index - 1 : e.key === 'ArrowRight' ? index + 1 : e.key === 'ArrowDown' ? 'down' : null;
@@ -93,7 +75,6 @@
           });
         });
 
-        // EWLJ-764: Add tab panel semantics and hide them all initially
         panels.forEach((panel, i) => {
           panel.setAttribute('role', 'tabpanel');
           panel.setAttribute('tabindex', '-1');
@@ -101,16 +82,9 @@
           panel.hidden = true;
         });
 
-        // EWLJ-764: Initially activate the first tab and reveal the first tab panel
         tabs[0].removeAttribute('tabindex');
         tabs[0].setAttribute('aria-selected', 'true');
         panels[0].hidden = false;
-        
-        // EWLJ-764: Trigger resize after the first load to ensure the correct aspect ratio
-        window.addEventListener('load', resizeIframe);
-
-        // EWLJ-764: Trigger resize on window resize to handle changes in viewport dimensions
-        window.addEventListener('resize', resizeIframe);
       });
     }
   };

--- a/styleguide/source/assets/js/vc-video-tabs.js
+++ b/styleguide/source/assets/js/vc-video-tabs.js
@@ -15,6 +15,11 @@
       // EWLJ-764: Select all tab groups on the page to handle multiple sets of tabs.
       const videoTabsGroups = document.querySelectorAll('.vc-video-tabs__group');
 
+      // EWLJ-764: Check if NodeList.forEach is supported
+      if (!NodeList.prototype.forEach) {
+        NodeList.prototype.forEach = Array.prototype.forEach; // Polyfill for forEach on NodeList
+      }
+
       // EWLJ-764: Loop through each video tab group and apply tab functionality.
       videoTabsGroups.forEach((videoTabs) => {
         const tablist = videoTabs.querySelector('ul');
@@ -23,10 +28,11 @@
 
         // The tab switching function
         const switchTab = (oldTab, newTab) => {
-          newTab.focus();
+          // EWLJ-764: Prevent focus issues in Safari by adding a small delay on focus
+          setTimeout(() => newTab.focus(), 0);
+
           // Make the active tab focusable by the user (Tab key)
           newTab.removeAttribute('tabindex');
-          // Set the selected state
           newTab.setAttribute('aria-selected', 'true');
           oldTab.removeAttribute('aria-selected');
           oldTab.setAttribute('tabindex', '-1');
@@ -39,53 +45,63 @@
           panels[index].hidden = false;
         };
 
-        // Add the tablist role to the first <ul> in the .vc-video-tabs__group container
+        // EWLJ-764: Add the tablist role to the first <ul> in the .vc-video-tabs__group container
         tablist.setAttribute('role', 'tablist');
 
-        // Add semantics and remove user focusability for each tab
-        Array.prototype.forEach.call(tabs, (tab, i) => {
+        // EWLJ-764: Add semantics and remove user focusability for each tab
+        tabs.forEach((tab, i) => {
           tab.setAttribute('role', 'tab');
           tab.setAttribute('id', `tab-${i + 1}`); // EWLJ-764: Updated ID format for better uniqueness
           tab.setAttribute('tabindex', '-1');
           tab.parentNode.setAttribute('role', 'presentation');
 
-          // Handle clicking of tabs for mouse users
+          // EWLJ-764: Handle clicking of tabs for mouse users
           tab.addEventListener('click', (e) => {
             e.preventDefault();
-            const currentTab = tablist.querySelector('[aria-selected]');
+            const currentTab = tablist.querySelector('[aria-selected="true"]');
             if (e.currentTarget !== currentTab) {
               switchTab(currentTab, e.currentTarget);
             }
           });
 
-          // Handle keydown events for keyboard users
+          // EWLJ-764: Handle keydown events for keyboard users with cross-browser support
           tab.addEventListener('keydown', (e) => {
-            // Get the index of the current tab in the tabs node list
             const index = Array.prototype.indexOf.call(tabs, e.currentTarget);
-            // Work out which key the user is pressing and
-            // Calculate the new tab's index where appropriate
-            const dir = e.which === 37 ? index - 1 : e.which === 39 ? index + 1 : e.which === 40 ? 'down' : null;
+            const dir = e.key === 'ArrowLeft' ? index - 1 : e.key === 'ArrowRight' ? index + 1 : e.key === 'ArrowDown' ? 'down' : null;
             if (dir !== null) {
               e.preventDefault();
-              // If the down key is pressed, move focus to the open panel,
-              // otherwise switch to the adjacent tab
-              return dir === 'down' ? panels[i].focus() : tabs[dir] ? switchTab(e.currentTarget, tabs[dir]) : 'undefined';
+              if (dir === 'down') {
+                panels[i].focus();
+              } else if (tabs[dir]) {
+                switchTab(e.currentTarget, tabs[dir]);
+              }
             }
           });
         });
 
-        // Add tab panel semantics and hide them all
-        Array.prototype.forEach.call(panels, (panel, i) => {
+        // EWLJ-764: Add tab panel semantics and hide them all initially
+        panels.forEach((panel, i) => {
           panel.setAttribute('role', 'tabpanel');
           panel.setAttribute('tabindex', '-1');
           panel.setAttribute('aria-labelledby', tabs[i].id);
           panel.hidden = true;
         });
 
-        // Initially activate the first tab and reveal the first tab panel
+        // EWLJ-764: Initially activate the first tab and reveal the first tab panel
         tabs[0].removeAttribute('tabindex');
         tabs[0].setAttribute('aria-selected', 'true');
         panels[0].hidden = false;
+        
+        // EWLJ-764: Force a resize after the first load to ensure the correct aspect ratio
+        window.addEventListener('load', () => {
+          panels.forEach(panel => {
+            const iframe = panel.querySelector('iframe');
+            if (iframe) {
+              iframe.style.height = '100%'; // Reapply height to enforce correct ratio
+              iframe.style.width = '100%';
+            }
+          });
+        });
       });
     }
   };

--- a/styleguide/source/assets/scss/03-organisms/_vc-video-tabs.scss
+++ b/styleguide/source/assets/scss/03-organisms/_vc-video-tabs.scss
@@ -30,20 +30,23 @@
   }
 }
 
-.vc-video-tabs__video {
-  position: relative;
-  width: 100%;
-  padding-bottom: 56.25%; /* 16:9 aspect ratio */
-  height: 0;
-  overflow: hidden;
-}
+/* Mobile-specific styling for video aspect ratio */
+@media (max-width: $bp-med - 1) {
+  .vc-video-tabs__video {
+    position: relative;
+    width: 100%;
+    padding-bottom: 56.25%; /* 16:9 aspect ratio */
+    height: 0;
+    overflow: hidden;
+  }
 
-.vc-video-tabs__video iframe {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
+  .vc-video-tabs__video iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
 }
 
 

--- a/styleguide/source/assets/scss/03-organisms/_vc-video-tabs.scss
+++ b/styleguide/source/assets/scss/03-organisms/_vc-video-tabs.scss
@@ -30,25 +30,13 @@
   }
 }
 
-/* Mobile-specific styling for video aspect ratio */
-@media (max-width: $bp-med - 1) {
-  .vc-video-tabs__video {
-    position: relative;
-    width: 100%;
-    padding-bottom: 56.25%; /* 16:9 aspect ratio */
-    height: 0;
-    overflow: hidden;
-  }
-
-  .vc-video-tabs__video iframe {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-  }
+/* Desktop and larger screens */
+.vc-video-tabs__video {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 9; /* Sets default aspect ratio on larger screens */
+  overflow: hidden;
 }
-
 
 .vc-video-tabs__group [role='tablist'] {
   padding: 0;
@@ -85,7 +73,7 @@
     }
   }
 
-  li+li a {
+  li + li a {
     @include breakpoint(0 $bp-med) {
       border-top: 0;
     }
@@ -116,7 +104,7 @@
   }
 }
 
-// Tab content
+// Tab content for larger screens, ensuring 16:9 aspect ratio with fallback for iframe inside the tab panels
 .vc-video-tabs__group [role='tabpanel'] {
   position: relative;
   aspect-ratio: 16 / 9;

--- a/styleguide/source/assets/scss/03-organisms/_vc-video-tabs.scss
+++ b/styleguide/source/assets/scss/03-organisms/_vc-video-tabs.scss
@@ -30,6 +30,23 @@
   }
 }
 
+.vc-video-tabs__video {
+  position: relative;
+  width: 100%;
+  padding-bottom: 56.25%; /* 16:9 aspect ratio */
+  height: 0;
+  overflow: hidden;
+}
+
+.vc-video-tabs__video iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+
 .vc-video-tabs__group [role='tablist'] {
   padding: 0;
   margin: 0 0 0.5rem;


### PR DESCRIPTION




**Jira Ticket**

- [EWLJ-764: (Mobile) Video Tabs component](https://ama-it.atlassian.net/browse/EWLJ-764)


## Description

Given: Individual has accessed JOE website through mobile device. When the user tries to view a video in the Video Tabs component Then the system should correct the aspect ratio on page load without any interaction from the user.

Current Behavior

In mobile - When first scrolling to the Video Tabs component, the preview image displayed for the first video in the tabs is not sized properly/is cut off (see firest screenshot below). Once you click on another video tab and then click back to the video 1 title tab, it resizes correctly (see second screenshot below).


## To Test

- [x] Create an "Art of medicine" content type.
- [x] Make sure to include some videos on "body content" tab under "body component" area.

![Screenshot_13-11-2024_183957_journalofethics lndo site](https://github.com/user-attachments/assets/76f28693-b80c-4e46-bb24-e9eab5c3e96a)

**Go to the page you just created and visualize it as Mobile device.**
![Screenshot 2024-11-13 at 18-43-43 Video tabs heading text test Journal of Ethics American Medical Association](https://github.com/user-attachments/assets/e17c6766-d84b-44dc-8275-dbfb5a4418fc)

**Both video sets should have the same aspect ratio.**

