### PR TITLE
EWLJ-858: style for read in links

### DIFF
--- a/styleguide/source/assets/scss/05-pages/_article.scss
+++ b/styleguide/source/assets/scss/05-pages/_article.scss
@@ -38,15 +38,39 @@
 .available__in {
   display: flex;
   align-items: center;
+  min-height: 25px;
+  margin: 1em 0;
+
   .joe__tags-title {
-    padding-top: 0.3em;
+    font-family: $franklin-gothic;
+    font-size: .8em;
+    font-weight: 700;
     letter-spacing: 0;
+    line-height: 1.35;
+    margin: 0 0.4em 0 0;
+    padding: 0;
+    height: 21px;
+  }
+  .joe__tags-list {
+    height: 21px;
+    overflow: hidden;
   }
   .joe__tags-list li {
     border-bottom: 0;
-
+    display: inline-block;
+    height: 21px;
+    margin: 0;
+    padding: 0;
+    > a:link,
     > a {
-      font-size: 0.95em;
+      font-size: 1em;
+      font-family: $franklin-gothic;
+      margin: 0;
+      padding: 0;
+      letter-spacing: 0;
+      display: block;
+      height: 21px;
+      border-bottom: 2px solid $orange-darker;
     }
   }
 }

--- a/styleguide/source/assets/scss/05-pages/_article.scss
+++ b/styleguide/source/assets/scss/05-pages/_article.scss
@@ -39,8 +39,7 @@
   display: flex;
   align-items: center;
   min-height: 25px;
-  margin: 1em 0;
-
+  margin: 1em 0 0.5em 0;
   .joe__tags-title {
     font-family: $franklin-gothic;
     font-size: .8em;


### PR DESCRIPTION
## Ticket(s)

Please do not submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**

**Jira Ticket**

- [EWLJ-858: Horizontal alignment of Read In languages](https://ama-it.atlassian.net/browse/EWLJ-858)


## Description

Add the style to the specific availabe__in links

## To Test

1. lando gulp serve
2. lando drush @journalofethics.local cr
3. Critical CSS module should be active 
4. Go to articles pages, Validate the alignment for the languages are correct
5. Go to an article page and validate the alignment for the languages are correct
6. See screenshot below

## Visual Regressions



## Relevant Screenshots/GIFs

![readlinks](https://github.com/user-attachments/assets/752cca76-1146-4cdb-91fe-b0d47a9b0c52)


## Remaining Tasks



## Additional Notes
