### PR TITLE
EWLJ-887: rtl for h2 on abstract

### DIFF
--- a/styleguide/source/assets/scss/00-base/_rtl.scss
+++ b/styleguide/source/assets/scss/00-base/_rtl.scss
@@ -38,9 +38,6 @@ article[dir='rtl'] {
   }
 
   .article_abstract {
-    > h2 {
-      text-align: left;
-    }
     p:first-of-type:not([dir="rtl"]) {
       text-align: left;
     }


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

Please do not submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**

- [Issue XXX: Issue Title](https://github.com/AmericanMedicalAssociation/joe-style-guide/issues/XXX)

**Jira Ticket**

- See ticket [EWLJ-887: Abstract Field for Translated Aritcles Display in Native Language](https://ama-it.atlassian.net/browse/EWLJ-887).


## Description

Removed alignment left for Abstract, it should be aligned to right.

## To Test

- See instructions on https://github.com/AmericanMedicalAssociation/code-of-ethics/pull/410

## Visual Regressions


## Relevant Screenshots/GIFs

![alignmentAbstract](https://github.com/user-attachments/assets/eb5cd59e-9cc5-4e30-bf2b-a18d4d30e714)


## Remaining Tasks

Remaining tasks?


## Additional Notes

Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
(https://github.com/AmericanMedicalAssociation/code-of-ethics/pull/410)
