### PR TITLE
EWLJ-902: Fix Broken Reference Tooltips on Article Pages

### DIFF
--- a/styleguide/source/assets/js/resource-tooltips.js
+++ b/styleguide/source/assets/js/resource-tooltips.js
@@ -26,7 +26,7 @@
         // Find the <sup> tag number and convert it into an integer
         var $supNumber = parseInt($(this).text()) - 1;
         // Take <sup> number and use it to get the reference
-        var $reference = $('.joe__references__list li').eq($supNumber);
+        var $reference = $('.joe__references__list').eq(1).find('li').eq($supNumber);
         // Prevent the hover function from cloning the reference more than once
         if (!$(this).find('.ama__tooltip').length) {
           // Append a div with the reference to the <sup>


### PR DESCRIPTION
<!-- NOTE: PLEASE INCLUDE THE JIRA TICKET IN THE PR TITLE in format: 'EWL-1234: Ticket Title' -->
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

# Pre-PR Checklist
If you have access to approved developer tools such as AMA co-pilot, ask it the following and test any suggestions before posting the PR.
- [x] Make this code secure.
- [x] Make this code null and empty safe.
- [x] Make this functionality accessible.
- [x] Make this code more efficient.
- [x] Beautify this code and comment it with lines above, not inline, that are no longer than 80 chars.


## JIRA Ticket(s)
[EWLJ-902: Incorrect order of references in JOE articles with other available translations](https://ama-it.atlassian.net/browse/EWLJ-902)

## Description:
On Article pages that are published in more than one language, the inline references (ie, when you hover the 1 superscript) are being populated with a hyperlink to the other available article translations (READ IN:) instead of the respective entry in the references list at the bottom of the page. 

**BEFORE**
![image](https://github.com/user-attachments/assets/1f08dfbc-2686-4351-877f-a2b353f817dd)

**AFTER**
![image](https://github.com/user-attachments/assets/48cdac7b-ef89-4c27-8e15-46519cfc1d0e)

## To Test:

**Setup**
- Pull branch [bugfix/EWLJ-902-fix-broken-reference-tooltips](https://github.com/AmericanMedicalAssociation/joe-style-guide/tree/bugfix/EWLJ-902-fix-broken-reference-tooltips)
- Serve and link SG
- Run `lando drush @journalofethics.local cr`
- Visit the following URLs, hover over the first couple of subscript numbers to display the tooltips.  Verify they are referencing the references list at the bottom of the page and not linking to the alternate translations from the READ IN list.

http://journalofethics.lndo.site/article/how-should-clinicians-respond-language-barriers-exacerbate-health-inequity/2021-02
http://journalofethics.lndo.site/article/key-roles-epistemic-humility-obgyn-care-patients-acute-non-labor-and-delivery-pain-care/2025-02


## Automated Test:
N/A

## Style Guide:
N/A

## Relevant Screenshots/GIFs:
N/A

## Additional Notes:
N/A

---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)
