### PR TITLE
EWLJ-1052: Add rule to exclude the title from the teaser reverse

### DIFF
--- a/styleguide/source/assets/scss/01-atoms/_headings.scss
+++ b/styleguide/source/assets/scss/01-atoms/_headings.scss
@@ -85,6 +85,7 @@ h6,
   h2
     :not(.vc-hero-art__flag-type)
     :not(.vc-hero-gallery__flag-type)
+    :not(.joe__article-teaser__title)
     :not(.vc-hero-gallery__flag-type) {
     font-size: clamp(2rem, 1.444rem + 2.468vw, 3.45rem);
   }


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

Please do not submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**

- [EWLJ-1052: JOE - Configure Teaser reverse mode for 3 art article types](https://github.com/AmericanMedicalAssociation/code-of-ethics/pull/457)

**Jira Ticket**

- See ticket [EWLJ-1052: JOE - Configure Teaser reverse mode for 3 art article types #457
](https://ama-it.atlassian.net/browse/EWLJ-1052).


## Description

Add the class to the teaser extended to exclude the style for this h2.

## To Test

## Visual Regressions



## Relevant Screenshots/GIFs

![1052style](https://github.com/user-attachments/assets/65f34310-edc6-4cfd-87bc-3bd3eedc6f56)


## Remaining Tasks

Remaining tasks?


## Additional Notes
