### PR TITLE
EWLJ-1050: Move content higher on homepage.

### DIFF
--- a/styleguide/source/assets/scss/01-atoms/_article-hero.scss
+++ b/styleguide/source/assets/scss/01-atoms/_article-hero.scss
@@ -1,6 +1,6 @@
 .joe__article-hero.is-front-page-specific {
   height: 900px;
-  margin-bottom: -750px;
+  margin-bottom: -600px;
 }
 
 .joe__article-hero {

--- a/styleguide/source/assets/scss/01-atoms/_article-hero.scss
+++ b/styleguide/source/assets/scss/01-atoms/_article-hero.scss
@@ -1,3 +1,8 @@
+.joe__article-hero.is-front-page-specific {
+  height: 500px;
+  margin-bottom: -350px;
+}
+
 .joe__article-hero {
   position: relative;
   width: 100%;
@@ -24,12 +29,7 @@
 
   @include breakpoint($bp-med) {
     height: 800px;
-    margin-bottom: -500px;
-  }
-
-  @include breakpoint($bp-large) {
-    height: 900px;
-    margin-bottom: -525px;
+    margin-bottom: -725px;
   }
 }
 

--- a/styleguide/source/assets/scss/01-atoms/_article-hero.scss
+++ b/styleguide/source/assets/scss/01-atoms/_article-hero.scss
@@ -1,6 +1,6 @@
 .joe__article-hero.is-front-page-specific {
-  height: 500px;
-  margin-bottom: -350px;
+  height: 900px;
+  margin-bottom: -750px;
 }
 
 .joe__article-hero {
@@ -29,7 +29,12 @@
 
   @include breakpoint($bp-med) {
     height: 800px;
-    margin-bottom: -725px;
+    margin-bottom: -500px;
+  }
+
+  @include breakpoint($bp-large) {
+    height: 900px;
+    margin-bottom: -525px;
   }
 }
 

--- a/styleguide/source/assets/scss/01-atoms/_flag.scss
+++ b/styleguide/source/assets/scss/01-atoms/_flag.scss
@@ -41,10 +41,9 @@
   .joe__issue-listing--current & {
     top: -2.7em;
     padding-top: 2em;
-
   }
   @include breakpoint($bp-xxs) {
-    padding: 0.75em 12px 10px;
+    padding: 1.6em 12px 10px;
     // top: -2em;
     .joe__poll & {
       top: -2.7em;

--- a/styleguide/source/assets/scss/01-atoms/_flag.scss
+++ b/styleguide/source/assets/scss/01-atoms/_flag.scss
@@ -31,20 +31,16 @@
 .joe__flag--larger {
   @include type($font-serif, .75em, $font-weight-medium, 1.25);
   padding: 0.75em 10px 10px;
-  // top: -1.3em;
   .joe__flag__type {
     display: block;
   }
-  .joe__poll & {
-    // top: -2em;
-  }
+
   .joe__issue-listing--current & {
     top: -2.7em;
     padding-top: 2em;
   }
   @include breakpoint($bp-xxs) {
     padding: 1.6em 12px 10px;
-    // top: -2em;
     .joe__poll & {
       top: -2.7em;
     }

--- a/styleguide/source/assets/scss/01-atoms/_flag.scss
+++ b/styleguide/source/assets/scss/01-atoms/_flag.scss
@@ -30,22 +30,22 @@
 
 .joe__flag--larger {
   @include type($font-serif, .75em, $font-weight-medium, 1.25);
-  padding: 2em 10px 10px;
-  top: -1.3em;
+  padding: 0.75em 10px 10px;
+  // top: -1.3em;
   .joe__flag__type {
     display: block;
   }
   .joe__poll & {
-    top: -2em;
+    // top: -2em;
   }
   .joe__issue-listing--current & {
     top: -2.7em;
     padding-top: 2em;
 
   }
-  @include breakpoint($bp-med) {
-    padding: 2.75em 12px 10px;
-    top: -2em;
+  @include breakpoint($bp-xxs) {
+    padding: 0.75em 12px 10px;
+    // top: -2em;
     .joe__poll & {
       top: -2.7em;
     }


### PR DESCRIPTION
## JIRA Ticket(s)

- See ticket [EWLJ-1050: JOE - Move content higher on homepage](https://ama-it.atlassian.net/browse/EWLJ-1050).

## Description

1. Move content box up by ~1/4-1/3

2. Reduce size of Issue date flag by 1/3

3. Move issue title up so that the bottom of line 1 of the Issue title lines up with the bottom of line 1 of the first Featured Article title. Ex in attachment: Bottom of Surgical should line up with the bottom of When. 

## Testing instructions

On Styleguide repo:
1. _Switch to branch EWLJ-1050_
2. _lando gulp serve

## Relevant Screenshots/gifs:

![Screenshot 2025-05-02 at 12-12-06 Journal of Ethics American Medical Association](https://github.com/user-attachments/assets/56fa484c-26b6-4fcf-84fd-4f5ae736f635)