### PR TITLE
EWLJ-1048: JOE - Reduce header image space on all listing pages.

### DIFF
--- a/styleguide/source/assets/scss/01-atoms/_article-hero.scss
+++ b/styleguide/source/assets/scss/01-atoms/_article-hero.scss
@@ -24,13 +24,9 @@
 
   @include breakpoint($bp-med) {
     height: 800px;
-    margin-bottom: -500px;
+    margin-bottom: -575px;
   }
 
-  @include breakpoint($bp-large) {
-    height: 900px;
-    margin-bottom: -525px;
-  }
 }
 
 .joe__article-hero--no-image {


### PR DESCRIPTION
**Jira Ticket**

- [EWLJ-1048 - Reduce header image space on all listing pages](https://ama-it.atlassian.net/browse/EWLJ-1048)


## Description

As discussed in the 4/28 sprint review meeting, we would like to reduce the amount of space between the white navigation menu and content on all listing pages. This includes:

Issues listing page

Articles listing page

Cases listing page

Art listing page

Multimedia listing page

CME listing page

Topics listing page 

The amount of space should mirror that spacing as seen on the Videocast content type. Ex: https://journalofethics.ama-assn.org/videocast/what-should-clinicians-and-patients-know-about-private-equity-health-care 


## To Test

On Styleguide repo:

Switch to branch EWLJ-1048
_lando gulp serve



## Relevant Screenshots/GIFs

![Screenshot 2025-05-04 at 22-08-57 Articles Journal of Ethics American Medical Association](https://github.com/user-attachments/assets/949c913e-9499-4fd2-9b67-5a7b0edc4088)




