### PR TITLE
EWLJ-1049: JOE - Move content higher on Issue Page.

### DIFF
--- a/styleguide/source/assets/scss/02-molecules/_issue-header.scss
+++ b/styleguide/source/assets/scss/02-molecules/_issue-header.scss
@@ -1,6 +1,6 @@
 .joe__issue-header {
   text-align: center;
-  margin: 1em auto 2em;
+  margin: .25em auto 2em;
   max-width: 1000px;
   border-bottom: 1px solid $black-05;
   padding-bottom: 1.5em;
@@ -14,7 +14,7 @@
 }
 
 .joe__issue-header__title {
-  margin-top: 1em;
+  margin-top: .25em;
   margin-bottom: .25em;
 }
 


### PR DESCRIPTION
**Jira Ticket**

- [EWL-1049: JOE - Move content higher on Issue Page](https://ama-it.atlassian.net/browse/EWLJ-1049)


## Description

We would like to move the content higher on the Isse page with the goal of revealing 2 lines of the issue title before the scroll. To do this, we would like to move the content box up by ~1/4-1/3. We would also like to slightly reduce the padding around the issue publishing date. See design mock up attached.JOE - Move content higher on Issue page.pptx 

Example of Issue page:[Surgical Care of Incarcerated Patients](https://journalofethics.ama-assn.org/issue/surgical-care-incarcerated-patients) 

In current laptop view, you can’t see any of the title without scrolling.


## To Test

On Styleguide repo:

Switch to branch EWLJ-1049
_lando gulp serve


## Relevant Screenshots/GIFs

![Screenshot 2025-05-04 at 23-47-26 Surgical Care of Incarcerated Patients Journal of Ethics American Medical Association](https://github.com/user-attachments/assets/ca9d2d17-c872-4858-83a4-264ceee4fe4f)



