### PR TITLE
EWLJ-972: JOE - Move content higher on article pages.

### DIFF
--- a/styleguide/source/assets/scss/01-atoms/_article-hero.scss
+++ b/styleguide/source/assets/scss/01-atoms/_article-hero.scss
@@ -14,7 +14,7 @@
 
   @include breakpoint($bp-xs) {
     height: 600px;
-    margin-bottom: -400px;
+    margin-bottom: -480px;
   }
 
   @include breakpoint($bp-small) {
@@ -35,12 +35,12 @@
 
 .joe__article-hero--no-image {
   height: 400px;
-  margin-bottom: -375px;
+  margin-bottom: -275px;
   max-width: none;
 
   @include breakpoint($bp-med) {
     height: 800px;
-    margin-bottom: -725px;
+    margin-bottom: -575px;
   }
   .joe__article-hero__overlay {
     display: none;

--- a/styleguide/source/assets/scss/01-atoms/_flag.scss
+++ b/styleguide/source/assets/scss/01-atoms/_flag.scss
@@ -30,7 +30,7 @@
 
 .joe__flag--larger {
   @include type($font-serif, .75em, $font-weight-medium, 1.25);
-  padding: 2em 10px 10px;
+  padding: 1em 10px 10px;
   top: -1.3em;
   .joe__flag__type {
     display: block;


### PR DESCRIPTION
**Jira Ticket**

- [EWLJ-972: JOE - Move content higher on article pages.](https://ama-it.atlassian.net/browse/EWLJ-972)


## Description

On desktop, we would like to move the content up on the Article content type by ~1/4-1/3 of the current header image space (see slide 1 of design mock up attaced). We would also like to reduce the padding on the article flag. Our ultimate goal is to be able to reveal 2 lines of the title before needed to scroll.

On mobile, we would like to move the content up on the Article content type similar to the spacing on the [Videocast content type](https://journalofethics.ama-assn.org/videocast/what-should-clinicians-and-patients-know-about-private-equity-health-care) (see slide 2 of design mock up attached. We would also like to reduce the padding on the article flag.


## To Test

Switch to branch EWLJ-972
_lando gulp serve


## Relevant Screenshots/GIFs

![Screenshot 2025-05-05 at 02-29-43 How Should Surgical Care Team Members Protect Incarcerated Patients From Carceral Officers’ Surveillance or Intrusion Journal of Ethics American Medical Association](https://github.com/user-attachments/assets/e5d46090-5125-4760-9053-3d170f76402a)


