### PR TITLE
Revert "EWLJ-1052: Add rule to exclude the title from the teaser reverse"

### DIFF
--- a/styleguide/source/assets/scss/01-atoms/_headings.scss
+++ b/styleguide/source/assets/scss/01-atoms/_headings.scss
@@ -85,7 +85,6 @@ h6,
   h2
     :not(.vc-hero-art__flag-type)
     :not(.vc-hero-gallery__flag-type)
-    :not(.joe__article-teaser__title)
     :not(.vc-hero-gallery__flag-type) {
     font-size: clamp(2rem, 1.444rem + 2.468vw, 3.45rem);
   }


### PR DESCRIPTION
Reverts AmericanMedicalAssociation/joe-style-guide#269