### PR TITLE
EWLJ-1064: Social icons on next line

### DIFF
--- a/styleguide/source/assets/scss/03-organisms/_vc-header.scss
+++ b/styleguide/source/assets/scss/03-organisms/_vc-header.scss
@@ -61,6 +61,19 @@
       text-decoration: underline;
     }
   }
+  // Social icons on next line
+  .joe__utility-nav__list--right {
+    .joe__utility-nav__item:not(.social) {
+      width: 100%;
+    }
+    .social {
+      margin-top: 8px;
+    }
+    .social-icon.facebook {
+      width: 15px;
+      padding-right: 5px;
+    }
+  }
 }
 
 // Art of Medicine header overrides
@@ -79,9 +92,9 @@
     .joe__wordmark a {
       color: var(--c-hero-text);
     }
-  
+
     .vc-header__action-button svg {
-  
+
       path,
       circle {
         stroke: var(--c-hero-text);

--- a/styleguide/source/assets/scss/03-organisms/_vc-header.scss
+++ b/styleguide/source/assets/scss/03-organisms/_vc-header.scss
@@ -72,6 +72,7 @@
     .social-icon.facebook {
       width: 15px;
       padding-right: 5px;
+      padding-left: 0;
     }
   }
 }


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

## Ticket(s)

Please do not submit a Pull Request without a relevant JIRA ticket or Github issue! If you are creating a new pattern or feature, create an issue describing the need for this feature in Github **first** and then link to it below.

**Github Issue**

- [Issue XXX: Issue Title](https://github.com/AmericanMedicalAssociation/joe-style-guide/issues/XXX)

**Jira Ticket**

- [EWLJ-1064: JOE - Update to Social Menu Links for Art Article Types](https://ama-it.atlassian.net/browse/EWLJ-1064)


## Description

- CSS to push social icons to next line, this change affects only Art of Medicine, Art Exhibition, Ethics Close Up)

## To Test

http://journalofethics.lndo.site:8000/article/wavering-branches-decision-tree/2025-05
http://journalofethics.lndo.site:8000/article/brief-history-healthier-comic-making/2025-06

## Visual Regressions

Does your work introduce any visual regressions to existing work in the Style Guide, or in a Drupal 8 environment? Please either call these out here or address them before marking your PR as `ready for review`.


## Relevant Screenshots/GIFs

![1064Fix](https://github.com/user-attachments/assets/4365b05e-7c55-4b2e-a87e-22366f095d64)


## Remaining Tasks

Remaining tasks?


## Additional Notes

Anything more to add? Good things to call out here are:
- are there any PRs in this or other repositories that relate to or affect this PR?
- are there any caveats or oddities testers should know about when testing this PR?
- are there any problems you ran into during your work that you'd like to call out?
